### PR TITLE
[codex] Add file-specific icon mappings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build generated theme variants
         run: node scripts/build-theme-variants.js
 
+      - name: Build generated file icons
+        run: npm run build:file-icons
+
       - name: Package VS Code extension
         run: npm run package
 

--- a/DEV.md
+++ b/DEV.md
@@ -1,0 +1,339 @@
+# Developer Guide
+
+Use this if you want to change the themes, build the install file, or help with the project.
+
+This guide uses plain words on purpose.
+
+## What This Project Is
+
+This folder is a VS Code extension.
+
+The extension adds:
+
+- color themes
+- file icon themes
+- folder icons
+- terminal colors
+- workbench colors
+
+The extension does not run a server.
+
+The extension does not compile an app.
+
+VS Code reads the JSON and SVG files in this repo.
+
+## Important Places
+
+| File or Folder | What It Does |
+| --- | --- |
+| `package.json` | Tells VS Code what this extension adds. |
+| `themes/` | Holds the color theme JSON files. |
+| `icons/` | Holds the dark icon theme files and dark SVG icons. |
+| `icons/light/` | Holds the light SVG icons. |
+| `icons/pixels-to-punk-cyber-icon-theme.json` | Maps files to dark icons. |
+| `icons/pixels-to-punk-cyber-light-icon-theme.json` | Maps files to light icons. |
+| `scripts/build-theme-variants.js` | Builds theme variants from palettes. |
+| `scripts/build-file-icons.js` | Builds file icons and icon maps. |
+| `scripts/terminal-colors.js` | Prints terminal colors for testing. |
+| `README.md` | Home page for the repo. |
+| `QUICKSTART.md` | Short install guide for users. |
+| `DEV.md` | This developer guide. |
+
+## Try The Extension From Source
+
+Use this when you want to test changes before making a release.
+
+1. Open VS Code.
+2. Open this folder: `vscode-themes-vibecoded`.
+3. Press `F5`.
+4. A second VS Code window opens.
+5. In the second window, press `Command + Shift + P`.
+6. Type:
+
+   ```text
+   Color Theme
+   ```
+
+7. Pick a **Pixels to Punk** theme.
+8. Press `Command + Shift + P` again.
+9. Type:
+
+   ```text
+   File Icon Theme
+   ```
+
+10. Pick **Pixels to Punk Cyber Icons** or **Pixels to Punk Cyber Icons Light**.
+
+## Change Theme Colors
+
+Theme colors live in `themes/`.
+
+To change one:
+
+1. Open a theme JSON file in `themes/`.
+2. Change one color.
+3. Save the file.
+4. Go to the Extension Development Host window.
+5. Run **Developer: Reload Window**.
+
+A color looks like this:
+
+```json
+"editor.background": "#101019"
+```
+
+The part with `#` is the color.
+
+## File Icons
+
+File icons are the tiny pictures beside file names in VS Code.
+
+They help people find files faster.
+
+Examples:
+
+- `index.ts` gets a TypeScript icon.
+- `App.tsx` gets a React icon.
+- `package.json` gets a package icon.
+- `README.md` gets a readme icon.
+- `.env` gets an environment icon.
+
+### Where To Update File Icons
+
+The icon recipe lives here:
+
+```text
+scripts/build-file-icons.js
+```
+
+The generated dark icons live here:
+
+```text
+icons/file-*.svg
+```
+
+The generated light icons live here:
+
+```text
+icons/light/file-*.svg
+```
+
+The dark icon map lives here:
+
+```text
+icons/pixels-to-punk-cyber-icon-theme.json
+```
+
+The light icon map lives here:
+
+```text
+icons/pixels-to-punk-cyber-light-icon-theme.json
+```
+
+### How To Add A File Icon
+
+1. Open `scripts/build-file-icons.js`.
+2. Add a new item to `iconSpecs`.
+3. Add the file extension, file name, or language ID to the right map.
+4. Run:
+
+   ```sh
+   npm run build:file-icons
+   ```
+
+5. Test the icon theme in VS Code.
+
+### When To Update File Icons
+
+Update file icons when:
+
+- a common file still looks plain
+- a new framework becomes important
+- a file icon is hard to read
+- the dark icon looks good but the light icon does not
+- the light icon looks good but the dark icon does not
+
+## Theme Fit Rule
+
+Do not assume one design works everywhere.
+
+This project has many moods:
+
+- dark
+- light
+- low-glare
+- neon
+- zine
+- rainy
+- high contrast
+
+When you add a new thing, ask:
+
+- What is this new thing?
+- How do people use it?
+- When should we update it?
+- Where in the repo do we update it?
+- Does it need dark and light versions?
+- Does it need high-contrast versions?
+- Does it need softer versions for eye-comfort themes?
+- Does it need louder versions for neon themes?
+
+The goal is not to make every theme identical.
+
+The goal is to make every theme feel like it belongs.
+
+## Test Terminal Colors
+
+The theme controls terminal colors.
+
+The terminal only shows those colors when a command prints colored text.
+
+This may look plain:
+
+```sh
+echo hello
+```
+
+That is normal.
+
+To test the terminal colors, run:
+
+```sh
+npm run demo:terminal-colors
+```
+
+You should see red, yellow, blue, magenta, cyan, white, and bright versions of those colors.
+
+## Build A Local VSIX
+
+Use this when you want to build the install file yourself.
+
+### Step 1: Install Node.js
+
+If you do not have Node.js yet:
+
+1. Go to <https://nodejs.org/>.
+2. Download the **LTS** version.
+3. Install it.
+4. Close VS Code.
+5. Open VS Code again.
+
+### Step 2: Install Project Tools
+
+Open the VS Code terminal and run:
+
+```sh
+npm install
+```
+
+### Step 3: Make The VSIX File
+
+Run:
+
+```sh
+npm run package
+```
+
+This makes a file that ends with `.vsix`.
+
+Do not run this unless you know why you need it:
+
+```sh
+npm audit fix --force
+```
+
+That command can make big dependency changes.
+
+The final `.vsix` file does not include `node_modules`.
+
+## Install A Local VSIX
+
+After `npm run package`, run:
+
+```sh
+code --install-extension pixels-to-punk-cyber-1.0.3.vsix --force
+```
+
+If the version changes, the file name changes too.
+
+## GitHub Releases
+
+This repo has a GitHub Action that builds the `.vsix` file.
+
+To run it by hand:
+
+1. Open the repo on GitHub.
+2. Click **Actions**.
+3. Click **Build VSIX**.
+4. Click **Run workflow**.
+
+To publish a real GitHub Release, push a version tag:
+
+```sh
+git tag v1.0.3
+git push origin v1.0.3
+```
+
+The action builds the `.vsix` file and attaches it to the GitHub Release for that tag.
+
+## Release Checklist
+
+When you change the extension and want a new release:
+
+1. Open `package.json`.
+2. Change the version number.
+3. Run:
+
+   ```sh
+   npm run package
+   ```
+
+4. Commit the changes.
+5. Tag the commit with the same version.
+6. Push the commit and tag.
+
+Example:
+
+```sh
+git add .
+git commit -m "Release v1.0.3"
+git tag v1.0.3
+git push origin main
+git push origin v1.0.3
+```
+
+## If The `code` Command Does Not Work
+
+If the terminal says `code: command not found`:
+
+1. Open the Command Palette with `Command + Shift + P`.
+2. Type:
+
+   ```text
+   Shell Command
+   ```
+
+3. Click **Shell Command: Install 'code' command in PATH**.
+4. Try the install command again.
+
+## Keep Learning
+
+The easiest way to learn theme-making is to change one color at a time.
+
+Good first colors to try:
+
+- `editor.background`
+- `editor.foreground`
+- `sideBar.background`
+- `statusBar.background`
+- `panel.background`
+- `panelTitle.activeBorder`
+- `problemsErrorIcon.foreground`
+- `debugConsole.infoForeground`
+- `terminal.background`
+- `terminal.foreground`
+- `terminal.ansiCyan`
+- `terminal.ansiMagenta`
+- `keyword`
+- `string`
+- `entity.name.function`

--- a/DEV.md
+++ b/DEV.md
@@ -43,6 +43,8 @@ VS Code reads the JSON and SVG files in this repo.
 
 Use this when you want to test changes before making a release.
 
+This works because VS Code can run a theme extension from its `package.json`.
+
 1. Open VS Code.
 2. Open this folder: `vscode-themes-vibecoded`.
 3. Press `F5`.
@@ -63,6 +65,10 @@ Use this when you want to test changes before making a release.
    ```
 
 10. Pick **Pixels to Punk Cyber Icons** or **Pixels to Punk Cyber Icons Light**.
+
+The extension defaults to **Pixels to Punk Cyber Icons**.
+
+If you test a light color theme, pick **Pixels to Punk Cyber Icons Light** by hand.
 
 ## Change Theme Colors
 
@@ -275,6 +281,8 @@ git push origin v1.0.3
 ```
 
 The action builds the `.vsix` file and attaches it to the GitHub Release for that tag.
+
+The workflow rebuilds generated theme variants and generated file icons before packaging.
 
 ## Release Checklist
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,72 @@
+# Quick Start
+
+Use this if you just want the themes.
+
+You do not need to know code.
+
+## Install The Themes
+
+1. Open the [latest download page](https://github.com/ryemyster/fptp-vscode-themes/releases/latest).
+2. Find the file that ends with `.vsix`.
+3. Download that file.
+4. Open VS Code.
+5. Click the blocks icon on the left. That is **Extensions**.
+6. Click the `...` button near the top.
+7. Click **Install from VSIX...**.
+8. Pick the `.vsix` file you downloaded.
+9. Click **Install**.
+
+That puts the theme pack into VS Code.
+
+## Pick A Color Theme
+
+1. Press `Command + Shift + P`.
+2. Type:
+
+   ```text
+   Color Theme
+   ```
+
+3. Click **Preferences: Color Theme**.
+4. Pick any theme that starts with **Pixels to Punk**.
+
+## Pick The File Icons
+
+1. Press `Command + Shift + P`.
+2. Type:
+
+   ```text
+   File Icon Theme
+   ```
+
+3. Click **Preferences: File Icon Theme**.
+4. Pick **Pixels to Punk Cyber Icons** for dark themes.
+5. Pick **Pixels to Punk Cyber Icons Light** for light themes.
+
+Now your folders and files should have Pixels to Punk icons.
+
+## If The Theme Does Not Show Up
+
+Sometimes VS Code needs a quick refresh.
+
+1. Press `Command + Shift + P`.
+2. Type:
+
+   ```text
+   Reload Window
+   ```
+
+3. Click **Developer: Reload Window**.
+4. Try picking the theme again.
+
+## What Changed?
+
+VS Code has new colors.
+
+Your files may have new icons.
+
+Your code did not change.
+
+Your projects did not change.
+
+Only VS Code got new clothes.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -32,6 +32,14 @@ That puts the theme pack into VS Code.
 
 ## Pick The File Icons
 
+The extension tries to start with **Pixels to Punk Cyber Icons**.
+
+That is the dark icon theme.
+
+VS Code does not switch icon themes when you switch color themes.
+
+So if you pick a light color theme, you may want to pick the light icon theme yourself.
+
 1. Press `Command + Shift + P`.
 2. Type:
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The icon themes are:
 - **Pixels to Punk Cyber Icons**
 - **Pixels to Punk Cyber Icons Light**
 
+VS Code can use one icon theme at a time. This extension defaults to **Pixels to Punk Cyber Icons**. If you use a light color theme, you can switch to **Pixels to Punk Cyber Icons Light** yourself.
+
 The file icons cover common things like JavaScript, TypeScript, React, HTML, CSS, JSON, Markdown, shell scripts, Git files, Docker files, YAML, Python, Rust, Go, `.env`, `package.json`, `README.md`, license files, config files, and GitHub files.
 
 ## What This Does

--- a/README.md
+++ b/README.md
@@ -1,604 +1,124 @@
 # Pixels to Punk Cyber
 
-A neon punk VS Code theme pack inspired by the [From Pixels to Punk](https://www.frompixelstopunk.com/) brand: loud, playful, anime-pop color, punk energy, and enough softness for long coding sessions.
+Pixels to Punk Cyber is a VS Code theme pack.
 
-This project is open source and repo-first. It is not published to the VS Code Marketplace.
+It gives VS Code new colors and new file icons. Think of it like giving your code editor a box of bright stickers, soft lights, and punk posters.
 
-## Start Here If You Are Not A Developer
+This project is open source and repo-first. It is not on the VS Code Marketplace right now.
 
-You do not need to know code.
+## Start Here
 
-Think of this like putting stickers on VS Code.
+If you only want to install the themes, go here:
 
-1. Open the [latest download page](https://github.com/ryemyster/fptp-vscode-themes/releases/latest).
-2. Find the file that ends with `.vsix`.
-3. Download that file.
-4. Open VS Code.
-5. Click the blocks icon on the left. That is Extensions.
-6. Click the `...` button near the top.
-7. Click **Install from VSIX...**.
-8. Pick the file you downloaded.
-9. Click **Install**.
-10. Press `Command + Shift + P`.
-11. Type `Color Theme`.
-12. Click **Preferences: Color Theme**.
-13. Pick a **Pixels to Punk** theme.
+[QUICKSTART.md](./QUICKSTART.md)
 
-That is it. VS Code has new clothes now.
+If you want to change the themes, build the install file, or help make the project better, go here:
 
-If you just want to use the themes, download the `.vsix` file from the latest GitHub Release and install it in VS Code.
+[DEV.md](./DEV.md)
 
-You get thirty color themes and two icon themes.
+## What You Get
 
-| Theme | Mode | What it feels like | Best for |
-| --- | --- | --- | --- |
-| **Pixels to Punk Cyber Dark** | Dark | The original dark palette: cyan glow, hot pink accents, and crisp blue-black chrome. | The default dark Pixels to Punk look. |
-| **Pixels to Punk Cyber Light** | Light | The original light palette: warm paper, teal controls, and punk magenta highlights. | The default light Pixels to Punk look. |
-| **Pixels to Punk Cyber Dark for Those with Glasses** | Dark | A researched lower-glare Cyber Dark remix with softened neon, less pure-black contrast shock, and high syntax contrast. | Eye strain, glasses, contacts, long night sessions, and W3C/WCAG-aware readability. |
-| **Pixels to Punk Cyber Light for Those with Glasses** | Light | A researched lower-glare Cyber Light remix with a warmer background, reduced white glare, and readable muted accents. | Eye strain, glasses, contacts, bright rooms, and W3C/WCAG-aware readability. |
-| **Pixels to Punk Neon Backstage** | Dark | Electric concert-night color with intense cyan, pink, and violet energy. | Maximum cyberpop drama. |
-| **Pixels to Punk Basement Flyer** | Dark | A gritty zine-poster palette with worn paper warmth and underground-show reds. | Punk texture without going fully neon. |
-| **Pixels to Punk CRT After Midnight** | Dark | Retro terminal glow with teal glass, cyan phosphor, and late-night amber. | Terminal-heavy work and nostalgic screens. |
-| **Pixels to Punk Candy Static** | Light | Bright arcade candy colors with playful pinks, blues, and yellows. | A high-energy light theme. |
-| **Pixels to Punk Streetlight Noir** | Dark | Cinematic late-night contrast with streetlight warmth and noir edges. | Dark workspaces that still want atmosphere. |
-| **Pixels to Punk Soft Focus Day** | Light | A calmer light palette with lower-glare surfaces and gentler accents. | Eye strain, daylight coding, and softer contrast. |
-| **Pixels to Punk Soft Focus Night** | Dark | A lower-luminance dark palette with softer text and less electric glare. | Eye strain, dim rooms, and long night sessions. |
-| **Pixels to Punk Rainy Arcade** | Dark | Blue rain, cyan glass, hot pink signage, and arcade-reflection color. | Moody neon without full saturation. |
-| **Pixels to Punk Photocopy Riot** | Light | Stark zine-paper contrast with red markup and blue ink. | Print-like light theme energy. |
-| **Pixels to Punk Afterparty Aquarium** | Dark | Deep teal nightlife with coral signage and soft cyan highlights. | Oceanic dark UI with party color. |
-| **Pixels to Punk Mall Goth Daydream** | Light | Lavender daylight, dark lipstick accents, and cooled-down neon. | A softer alt-pop light theme. |
-| **Pixels to Punk Riot Glow Dark** | Dark | Saturated violet chrome with cyan, neon pink, red-orange, and arcade yellow. | The loudest dark theme in the pack. |
-| **Pixels to Punk Riot Glow Light** | Light | Bright lavender paper with the same cyan, neon pink, red-orange, and arcade yellow punch. | The loudest light theme in the pack. |
-| **Pixels to Punk Sticker Bomb Sunset** | Dark | Warm hot-pink stickers, orange signage, and cyan ink on a violet night base. | A warmer punk-pop dark theme. |
-| **Pixels to Punk Laser Lemonade** | Dark | Electric yellow, cyan, and magenta on crisp blue-black chrome. | High-energy coding without the full violet wash. |
-| **Pixels to Punk Bubblegum Bruise** | Dark | Bubblegum pink, bruised violet, cyan edge light, and soft orange syntax. | Cute-night neon with a harder outline. |
-| **Pixels to Punk Punk Pool Party** | Dark | Deep teal-blue surfaces with coral signage, cyan controls, and yellow glow. | A brighter aqua nightlife mood. |
-| **Pixels to Punk Cherry CRT** | Dark | Cherry red, cyan phosphor, violet type, and warm terminal amber. | Retro punk terminals without green phosphor. |
-| **Pixels to Punk Electric Sticker Sheet** | Light | White sticker paper, electric violet, cyan-blue, yellow, and poster orange. | A crisp branded light theme. |
-| **Pixels to Punk Zine Shop Window** | Light | Warm shop-window paper with black ink, blue signage, and hot pink markup. | Zine energy with higher light-theme clarity. |
-| **Pixels to Punk Blacklight Slushie** | Dark | Blue-black slush, violet glow, cyan signage, and neon pink accents. | The most logo-faithful new dark remix. |
-| **Pixels to Punk Toxic Valentine** | Dark | Hot pink, violet-blue, coral-orange, and midnight purple. | Punk romance without leaving the brand palette. |
-| **Pixels to Punk Arcade Raincoat** | Dark | Rainy navy, cyan-blue reflections, hot pink signs, and yellow street glow. | Moody arcade rain with strong readability. |
-| **Pixels to Punk Original** | Dark | Sampled from the FPTP image: blue-black, indigo, violet, cyan, hot pink, coral-red, and white. | The closest match to the source artwork. |
-| **Pixels to Punk Original High Contrast** | High Contrast Dark | The source-art palette tightened for stronger text, borders, and selections. | Maximum readability while staying FPTP. |
-| **Pixels to Punk Electric Sticker Sheet High Contrast** | High Contrast Light | A sharper light sticker palette with deeper text and stronger controls. | Bright-room readability with brand color. |
+You get:
 
-The icon themes are **Pixels to Punk Cyber Icons** and **Pixels to Punk Cyber Icons Light**.
+- 30 color themes
+- 2 icon themes
+- dark themes
+- light themes
+- lower-glare themes
+- high-contrast themes
+- special file icons for common code files
+- terminal colors
+- Git, Problems, Debug Console, and Output panel colors
 
-### Eye Strain And Accessibility Notes
+The icon themes are:
 
-The glasses/contact-friendly themes and the Soft Focus themes were designed after research into practical screen comfort and accessibility guidance, especially [W3C/WAI low vision needs](https://www.w3.org/TR/low-vision-needs/), [WCAG contrast guidance](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum), and optometry guidance around glare and computer vision strain from the [American Optometric Association](https://www.aoa.org/healthy-eyes/eye-and-vision-conditions/computer-vision-syndrome).
+- **Pixels to Punk Cyber Icons**
+- **Pixels to Punk Cyber Icons Light**
 
-The main design choices are:
+The file icons cover common things like JavaScript, TypeScript, React, HTML, CSS, JSON, Markdown, shell scripts, Git files, Docker files, YAML, Python, Rust, Go, `.env`, `package.json`, `README.md`, license files, config files, and GitHub files.
 
-- reduce glare from pure white or pure black surfaces
-- keep normal code text at strong contrast against the editor background
-- avoid relying on hue alone for syntax meaning
-- soften saturated neon colors while preserving the Cyber identity
-- make comments, line numbers, warnings, and errors readable enough for long sessions
+## What This Does
 
-These themes are not medical treatment. They are practical color-system variants for people who notice more glare, halos, dryness, or fatigue when coding with glasses or contacts.
+This extension changes how VS Code looks.
 
-If a newly installed theme does not appear in the picker right away, run **Developer: Reload Window** in VS Code, then open **Preferences: Color Theme** again.
+It can change:
 
-The matching folder icons are set as the default icon theme when this extension is installed.
+- the editor background
+- code colors
+- sidebars
+- tabs
+- buttons
+- terminal colors
+- warning and error colors
+- folder icons
+- file icons
 
-If you already chose a different icon theme before, VS Code may keep your choice. You can still turn these icons on by hand.
+It does not change your code.
 
-## Install From GitHub Releases
+It does not run your app.
 
-Use this if you are not a developer and just want the themes in VS Code.
+It just makes VS Code feel more like Pixels to Punk.
 
-1. Go to the [Releases page](https://github.com/ryemyster/fptp-vscode-themes/releases).
-2. Open the newest release.
-3. Download the file that ends in `.vsix`.
-4. Open VS Code.
-5. Click the **Extensions** icon on the left side.
-6. Click the `...` menu at the top of the Extensions panel.
-7. Click **Install from VSIX...**.
-8. Pick the `.vsix` file you downloaded.
-9. Click **Install**.
-10. Press `Command + Shift + P`.
-11. Type:
+## Theme List
 
-   ```text
-   Color Theme
-   ```
+| Theme | Mode | Short Version |
+| --- | --- | --- |
+| Pixels to Punk Cyber Dark | Dark | The main dark look with cyan and hot pink. |
+| Pixels to Punk Cyber Light | Light | The main light look with warm paper and bright accents. |
+| Pixels to Punk Cyber Dark for Those with Glasses | Dark | Softer dark colors for long sessions. |
+| Pixels to Punk Cyber Light for Those with Glasses | Light | Softer light colors for bright rooms. |
+| Pixels to Punk Neon Backstage | Dark | Loud concert-night neon. |
+| Pixels to Punk Basement Flyer | Dark | Gritty punk poster colors. |
+| Pixels to Punk CRT After Midnight | Dark | Retro screen glow. |
+| Pixels to Punk Candy Static | Light | Bright candy arcade colors. |
+| Pixels to Punk Streetlight Noir | Dark | Rainy night streetlight colors. |
+| Pixels to Punk Soft Focus Day | Light | Calm daylight colors. |
+| Pixels to Punk Soft Focus Night | Dark | Calm night colors. |
+| Pixels to Punk Rainy Arcade | Dark | Blue rain and arcade glow. |
+| Pixels to Punk Photocopy Riot | Light | Zine paper with red and blue ink. |
+| Pixels to Punk Afterparty Aquarium | Dark | Deep teal with coral lights. |
+| Pixels to Punk Mall Goth Daydream | Light | Soft lavender alt-pop colors. |
+| Pixels to Punk Riot Glow Dark | Dark | One of the loudest dark themes. |
+| Pixels to Punk Riot Glow Light | Light | One of the loudest light themes. |
+| Pixels to Punk Sticker Bomb Sunset | Dark | Warm stickers and sunset neon. |
+| Pixels to Punk Laser Lemonade | Dark | Yellow, cyan, and magenta energy. |
+| Pixels to Punk Bubblegum Bruise | Dark | Pink, violet, cyan, and orange. |
+| Pixels to Punk Punk Pool Party | Dark | Aqua nightlife colors. |
+| Pixels to Punk Cherry CRT | Dark | Cherry red and cyan screen glow. |
+| Pixels to Punk Electric Sticker Sheet | Light | Clean sticker-paper color. |
+| Pixels to Punk Zine Shop Window | Light | Warm shop-window zine colors. |
+| Pixels to Punk Blacklight Slushie | Dark | Blue-black, violet, cyan, and pink. |
+| Pixels to Punk Toxic Valentine | Dark | Hot pink and midnight violet. |
+| Pixels to Punk Arcade Raincoat | Dark | Rainy navy with yellow street glow. |
+| Pixels to Punk Original | Dark | Closest to the source art palette. |
+| Pixels to Punk Original High Contrast | High Contrast Dark | Stronger dark readability. |
+| Pixels to Punk Electric Sticker Sheet High Contrast | High Contrast Light | Stronger light readability. |
 
-12. Click **Preferences: Color Theme**.
-13. Pick any **Pixels to Punk** color theme.
-14. Press `Command + Shift + P` again.
-15. Type:
+## Eye Comfort
 
-   ```text
-   File Icon Theme
-   ```
+Some themes are made to be easier on tired eyes.
 
-16. Click **Preferences: File Icon Theme**.
-17. Pick **Pixels to Punk Cyber Icons** or **Pixels to Punk Cyber Icons Light**.
+Look for:
 
-## For Developers
-
-Use this if you want to change the themes, remix them, or test them from source.
-
-## What This Project Is
-
-This folder is a tiny VS Code extension.
-
-The extension does one job: it adds color themes to VS Code.
-
-The important files are:
-
-- `package.json`: tells VS Code that this extension exists.
-- `themes/pixels-to-punk-cyber-dark-color-theme.json`: the default dark theme colors.
-- `themes/pixels-to-punk-cyber-light-color-theme.json`: the default light theme colors.
-- `themes/pixels-to-punk-cyber-dark-for-those-with-glasses-color-theme.json`: lower-glare dark cyber colors with softer accents and stronger reading contrast.
-- `themes/pixels-to-punk-cyber-light-for-those-with-glasses-color-theme.json`: warmer light cyber colors with reduced white glare and clearer syntax contrast.
-- `themes/pixels-to-punk-neon-backstage-color-theme.json`: electric concert-night colors.
-- `themes/pixels-to-punk-basement-flyer-color-theme.json`: gritty zine-poster colors.
-- `themes/pixels-to-punk-crt-after-midnight-color-theme.json`: retro terminal glow colors.
-- `themes/pixels-to-punk-candy-static-color-theme.json`: bright candy arcade colors.
-- `themes/pixels-to-punk-streetlight-noir-color-theme.json`: cinematic late-night colors.
-- `themes/pixels-to-punk-soft-focus-day-color-theme.json`: lower-glare light colors for normal room lighting.
-- `themes/pixels-to-punk-soft-focus-night-color-theme.json`: lower-luminance dark colors for dimmer rooms.
-- `themes/pixels-to-punk-rainy-arcade-color-theme.json`: blue rain, cyan glass, and hot pink arcade glow.
-- `themes/pixels-to-punk-photocopy-riot-color-theme.json`: stark zine-paper contrast with red markup and blue ink.
-- `themes/pixels-to-punk-afterparty-aquarium-color-theme.json`: deep teal nightlife with coral signage and soft cyan highlights.
-- `themes/pixels-to-punk-mall-goth-daydream-color-theme.json`: lavender daylight, dark lipstick accents, and cooled-down neon.
-- `themes/pixels-to-punk-riot-glow-dark-color-theme.json`: saturated violet chrome with cyan, neon pink, red-orange, and arcade yellow.
-- `themes/pixels-to-punk-riot-glow-light-color-theme.json`: bright lavender paper with the same cyan, neon pink, red-orange, and arcade yellow punch.
-- `themes/pixels-to-punk-sticker-bomb-sunset-color-theme.json`: warm hot-pink stickers, orange signage, and cyan ink.
-- `themes/pixels-to-punk-laser-lemonade-color-theme.json`: electric yellow, cyan, and magenta on blue-black chrome.
-- `themes/pixels-to-punk-bubblegum-bruise-color-theme.json`: bubblegum pink, bruised violet, cyan edge light, and orange syntax.
-- `themes/pixels-to-punk-punk-pool-party-color-theme.json`: teal-blue surfaces with coral signage and cyan controls.
-- `themes/pixels-to-punk-cherry-crt-color-theme.json`: cherry red, cyan phosphor, violet type, and warm terminal amber.
-- `themes/pixels-to-punk-electric-sticker-sheet-color-theme.json`: white sticker paper with electric violet and cyan-blue.
-- `themes/pixels-to-punk-zine-shop-window-color-theme.json`: warm shop-window paper with black ink, blue signage, and hot pink markup.
-- `themes/pixels-to-punk-blacklight-slushie-color-theme.json`: blue-black slush, violet glow, cyan signage, and neon pink accents.
-- `themes/pixels-to-punk-toxic-valentine-color-theme.json`: hot pink, violet-blue, coral-orange, and midnight purple.
-- `themes/pixels-to-punk-arcade-raincoat-color-theme.json`: rainy navy, cyan-blue reflections, hot pink signs, and yellow street glow.
-- `themes/pixels-to-punk-original-color-theme.json`: source-art sampled FPTP image colors.
-- `themes/pixels-to-punk-original-high-contrast-color-theme.json`: source-art palette tightened for high contrast.
-- `themes/pixels-to-punk-electric-sticker-sheet-high-contrast-color-theme.json`: high-contrast light sticker palette.
-- `icons/pixels-to-punk-cyber-icon-theme.json`: the matching folder icons.
-
-## Try It Right Now
-
-Use this when you want to test the theme before installing it forever.
-
-1. Open VS Code.
-2. Click **File**.
-3. Click **Open Folder...**.
-4. Pick this folder: `vscode-themes-vibecoded`.
-5. Press `F5`.
-6. A second VS Code window opens. That second window is called the **Extension Development Host**.
-7. In the second window, press:
-
-   ```text
-   Command + Shift + P
-   ```
-
-8. Type:
-
-   ```text
-   Color Theme
-   ```
-
-9. Click **Preferences: Color Theme**.
-10. Pick any **Pixels to Punk** color theme.
-11. Press `Command + Shift + P` again.
-12. Type:
-
-   ```text
-   File Icon Theme
-   ```
-
-13. Click **Preferences: File Icon Theme**.
-14. Pick **Pixels to Punk Cyber Icons** for the dark theme or **Pixels to Punk Cyber Icons Light** for the light theme.
-
-That is it. You are now testing your theme.
-
-## Change Colors
-
-The colors live in the `themes` folder.
-
-To change the dark theme:
-
-1. Open `themes/pixels-to-punk-cyber-dark-color-theme.json`.
-2. Change one color.
-3. Save the file.
-4. Go back to the second VS Code window.
-5. Run **Developer: Reload Window** from the Command Palette.
-
-To change the light theme:
-
-1. Open `themes/pixels-to-punk-cyber-light-color-theme.json`.
-2. Change one color.
-3. Save the file.
-4. Go back to the second VS Code window.
-5. Run **Developer: Reload Window** from the Command Palette.
-
-Colors look like this:
-
-```json
-"editor.background": "#101019"
-```
-
-The part with `#` is the color.
-
-## Turn On Folder Icons
-
-The color theme changes editor colors.
-
-The file icon theme changes folder icons in the Explorer.
-
-This project tries to turn on **Pixels to Punk Cyber Icons** automatically.
-
-If the folder icons do not change, turn them on by hand:
-
-To turn on the matching folder icons:
-
-1. Press `Command + Shift + P`.
-2. Type:
-
-   ```text
-   File Icon Theme
-   ```
-
-3. Click **Preferences: File Icon Theme**.
-4. Pick **Pixels to Punk Cyber Icons** for the dark theme or **Pixels to Punk Cyber Icons Light** for the light theme.
-
-Your folder icons should now use cyber cyan and punk pink.
-
-## Problems, Debug Console, And Output
-
-The bottom panel has tabs like **Terminal**, **Problems**, **Debug Console**, and **Output**.
-
-This theme colors the panel background, active tab underline, warning icons, error icons, info icons, debug messages, and terminal ANSI colors.
-
-Plain text may still look mostly normal. That is expected. VS Code and command-line tools only use special colors when they mark text as an error, warning, info message, success message, or ANSI color.
-
-## Test Terminal Colors
-
-The theme controls the terminal color palette.
-
-But the terminal only shows those colors when a command prints colored text.
-
-That means this kind of output may look plain:
-
-```sh
-echo hello
-```
-
-That is normal.
-
-To test the terminal colors, run:
-
-```sh
-npm run demo:terminal-colors
-```
-
-You should see red, yellow, blue, magenta, cyan, white, and bright versions of those colors.
-
-If that test is colorful, the theme is working.
-
-If your normal terminal still looks mostly white, that just means your shell prompt or command output is not asking VS Code to use colors yet.
-
-## Make Terminal Folders Colorful
-
-The terminal screenshot may show folder names as plain white because macOS `ls` does not always print colors.
-
-Try this command:
-
-```sh
-ls -G
-```
-
-If that shows colored folders, you can make it easier with an alias.
-
-Open your shell file:
-
-```sh
-open ~/.zshrc
-```
-
-Add this line:
-
-```sh
-alias ls="ls -G"
-```
-
-Then restart the terminal.
-
-Now `ls` should use colors, and VS Code will map those colors through this theme's terminal palette.
-
-To see hidden files too, use:
-
-```sh
-ls -laG
-```
-
-## Build A Local VSIX
-
-Use this when you want to build the install file yourself.
-
-### Step 1: Install Node.js
-
-If you do not have Node.js yet:
-
-1. Go to <https://nodejs.org/>.
-2. Download the **LTS** version.
-3. Install it.
-4. Close VS Code.
-5. Open VS Code again.
-
-### Step 2: Install Project Tools
-
-Open the VS Code terminal:
-
-1. Click **Terminal**.
-2. Click **New Terminal**.
-3. Run this command:
-
-```sh
-npm install
-```
-
-### Step 3: Make The VSIX File
-
-Run this command:
-
-```sh
-npm run package
-```
-
-This makes a file named:
-
-```text
-pixels-to-punk-cyber-1.0.0.vsix
-```
-
-If npm prints warnings about old packages, do not panic.
-
-This project uses the official VS Code packaging tool, and that tool installs helper packages behind the scenes.
-
-Do **not** run this unless you know why you need it:
-
-```sh
-npm audit fix --force
-```
-
-That command can make big dependency changes.
-
-For this project, `npm audit fix --force` may even try to downgrade the VS Code packaging tool.
-
-That is not helpful.
-
-The final `.vsix` file does **not** include `node_modules`.
-
-That means those npm warnings are about the local build tool, not about the theme files people download.
-
-If npm says there is a newer version of `@vscode/vsce`, that is just the packaging tool saying it has an update available.
-
-You do not need to update it just to build this theme.
-
-### Step 4: Install The Theme Locally
-
-Run this command:
-
-```sh
-code --install-extension pixels-to-punk-cyber-1.0.0.vsix --force
-```
-
-### Step 5: Turn It On
-
-1. Press `Command + Shift + P`.
-2. Type:
-
-   ```text
-   Color Theme
-   ```
-
-3. Click **Preferences: Color Theme**.
-4. Pick any **Pixels to Punk** color theme.
-5. Press `Command + Shift + P` again.
-6. Type:
-
-   ```text
-   File Icon Theme
-   ```
-
-7. Click **Preferences: File Icon Theme**.
-8. Pick **Pixels to Punk Cyber Icons** for the dark theme or **Pixels to Punk Cyber Icons Light** for the light theme.
-
-## GitHub Releases
-
-This repo has a GitHub Action that builds the `.vsix` file automatically.
-
-You can run it by hand:
-
-1. Open the repo on GitHub.
-2. Click **Actions**.
-3. Click **Build VSIX**.
-4. Click **Run workflow**.
-
-That creates a downloadable workflow artifact.
-
-To publish a real GitHub Release, push a version tag:
-
-```sh
-git tag v1.0.0
-git push origin v1.0.0
-```
-
-The action will build the `.vsix` file and attach it to the GitHub Release for that tag.
-
-## Website Link
-
-Since this is not on the VS Code Marketplace, link people to the repo or the latest release.
-
-Repo link:
-
-```text
-https://github.com/ryemyster/fptp-vscode-themes
-```
-
-Latest release link:
-
-```text
-https://github.com/ryemyster/fptp-vscode-themes/releases/latest
-```
-
-Simple website copy:
-
-```html
-<a href="https://github.com/ryemyster/fptp-vscode-themes/releases/latest">
-  Download the Pixels to Punk VS Code themes
-</a>
-```
-
-## Update The Theme Later
-
-When you change colors and want a new release:
-
-1. Open `package.json`.
-2. Change the version number.
-
-Example:
-
-```json
-"version": "1.0.0"
-```
-
-3. Run:
-
-```sh
-npm run package
-```
-
-4. Commit the changes.
-5. Tag the commit with the same version.
-6. Push the commit and tag.
-
-Example:
-
-```sh
-git add .
-git commit -m "Release v1.0.0"
-git tag v1.0.0
-git push origin main
-git push origin v1.0.0
-```
-
-The GitHub Action will publish the release file.
-
-## If The `code` Command Does Not Work
-
-If the terminal says `code: command not found`, do this:
-
-1. Open the Command Palette with `Command + Shift + P`.
-2. Type:
-
-   ```text
-   Shell Command
-   ```
-
-3. Click **Shell Command: Install 'code' command in PATH**.
-4. Try the install command again:
-
-   ```sh
-   code --install-extension pixels-to-punk-cyber-1.0.0.vsix --force
-   ```
-
-## Tiny Color Map
-
-Dark theme:
-
-- Background: deep midnight purple-black.
-- Main text: soft blue-white.
-- Keywords: hot punk pink.
-- Functions: electric cyan.
-- Strings: neon mint.
-- Numbers: warm arcade yellow.
-
-Light theme:
-
-- Background: warm off-white.
-- Main text: dark ink.
-- Keywords: punchy magenta.
-- Functions: deep cyan.
-- Strings: readable cyan.
-- Numbers: warm amber.
-
-Neon Backstage:
-
-- Background: near-black show-night blue.
-- Main text: crisp stage white.
-- Keywords: neon pink.
-- Functions: sign-glow cyan.
-- Strings: hot orange.
-- Numbers: marquee yellow.
-
-Basement Flyer:
-
-- Background: charcoal paper.
-- Main text: warm off-white.
-- Keywords: worn poster red.
-- Functions: muted teal.
-- Strings: mustard gold.
-- Numbers: faded orange.
-
-CRT After Midnight:
-
-- Background: deep blue-black.
-- Main text: phosphor mint.
-- Keywords: synth magenta.
-- Functions: electric teal.
-- Strings: cyan monitor glow.
-- Numbers: amber terminal light.
-
-Candy Static:
-
-- Background: pale lavender-white.
-- Main text: dark ink.
-- Keywords: bubblegum magenta.
-- Functions: arcade blue.
-- Strings: clean cyan.
-- Numbers: caramel amber.
-
-Streetlight Noir:
-
-- Background: rain-dark ink.
-- Main text: smoky off-white.
-- Keywords: dusty rose.
-- Functions: steel blue.
-- Strings: streetlamp gold.
-- Numbers: warm brass.
-
-## Keep Learning
-
-The easiest way to learn theme-making is to change one color at a time.
-
-Good first colors to play with:
-
-- `editor.background`
-- `editor.foreground`
-- `sideBar.background`
-- `statusBar.background`
-- `panel.background`
-- `panelTitle.activeBorder`
-- `problemsErrorIcon.foreground`
-- `debugConsole.infoForeground`
-- `terminal.background`
-- `terminal.foreground`
-- `terminal.ansiCyan`
-- `terminal.ansiMagenta`
-- `keyword`
-- `string`
-- `entity.name.function`
-
-## License
-
-This project is released under the [MIT License](./LICENSE).
-
-You can use it, copy it, change it, fork it, remix it, and share it. Keep the license notice with copies or substantial portions of the project.
+- **for Those with Glasses**
+- **Soft Focus Day**
+- **Soft Focus Night**
+- **High Contrast**
+
+These themes try to:
+
+- reduce bright white glare
+- avoid harsh pure-black contrast
+- keep code readable
+- keep comments and line numbers visible
+- avoid using only color to show meaning
+
+They are not medical treatment. They are just careful color choices for people who notice eye strain.
+
+## Links
+
+- [Quick install guide](./QUICKSTART.md)
+- [Developer guide](./DEV.md)
+- [Latest download page](https://github.com/ryemyster/fptp-vscode-themes/releases/latest)
+- [All releases](https://github.com/ryemyster/fptp-vscode-themes/releases)
+- [License](./LICENSE)

--- a/icons/file-config.svg
+++ b/icons/file-config.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#A5A8C4" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#A5A8C4"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#101019">*</text>
+</svg>

--- a/icons/file-css.svg
+++ b/icons/file-css.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#5EA8FF" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#5EA8FF"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="4" font-weight="800" fill="#08111E">CSS</text>
+</svg>

--- a/icons/file-docker.svg
+++ b/icons/file-docker.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#24D9FF" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#24D9FF"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#071820">DK</text>
+</svg>

--- a/icons/file-env.svg
+++ b/icons/file-env.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#66F29A" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#66F29A"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="4" font-weight="800" fill="#06200F">ENV</text>
+</svg>

--- a/icons/file-git.svg
+++ b/icons/file-git.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#FF4C6A" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FF4C6A"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#26070D">G</text>
+</svg>

--- a/icons/file-github.svg
+++ b/icons/file-github.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#9C7BFF" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#9C7BFF"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#111022">GH</text>
+</svg>

--- a/icons/file-go.svg
+++ b/icons/file-go.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#66F2E8" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#66F2E8"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#061C1A">GO</text>
+</svg>

--- a/icons/file-html.svg
+++ b/icons/file-html.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#FF7A45" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FF7A45"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#1B0D08">H5</text>
+</svg>

--- a/icons/file-js.svg
+++ b/icons/file-js.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#FFE05C" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FFE05C"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#1B1726">JS</text>
+</svg>

--- a/icons/file-json.svg
+++ b/icons/file-json.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#FF36B7" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FF36B7"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#240018">{}</text>
+</svg>

--- a/icons/file-license.svg
+++ b/icons/file-license.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#B8C8D8" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#B8C8D8"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="4" font-weight="800" fill="#202235">MIT</text>
+</svg>

--- a/icons/file-md.svg
+++ b/icons/file-md.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#E8EDF7" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#E8EDF7"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#202235">MD</text>
+</svg>

--- a/icons/file-package.svg
+++ b/icons/file-package.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#FF36B7" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FF36B7"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="4" font-weight="800" fill="#240018">PKG</text>
+</svg>

--- a/icons/file-python.svg
+++ b/icons/file-python.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#FFE05C" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FFE05C"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#15151F">PY</text>
+</svg>

--- a/icons/file-react.svg
+++ b/icons/file-react.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#9C7BFF" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#9C7BFF"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#111022">RX</text>
+</svg>

--- a/icons/file-readme.svg
+++ b/icons/file-readme.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#E8EDF7" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#E8EDF7"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#202235">RD</text>
+</svg>

--- a/icons/file-rust.svg
+++ b/icons/file-rust.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#FF7A45" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FF7A45"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#1C0C05">RS</text>
+</svg>

--- a/icons/file-shell.svg
+++ b/icons/file-shell.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#66F29A" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#66F29A"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#06200F">$_</text>
+</svg>

--- a/icons/file-ts.svg
+++ b/icons/file-ts.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#24D9FF" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#24D9FF"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#08141C">TS</text>
+</svg>

--- a/icons/file-yaml.svg
+++ b/icons/file-yaml.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#101019"/>
+  <path d="M9 2v3h3" fill="#FFB15E" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#24D9FF" stroke-opacity=".5"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".38"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FFB15E"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#241406">Y</text>
+</svg>

--- a/icons/light/file-config.svg
+++ b/icons/light/file-config.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#A5A8C4" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#A5A8C4"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#101019">*</text>
+</svg>

--- a/icons/light/file-css.svg
+++ b/icons/light/file-css.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#5EA8FF" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#5EA8FF"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="4" font-weight="800" fill="#08111E">CSS</text>
+</svg>

--- a/icons/light/file-docker.svg
+++ b/icons/light/file-docker.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#24D9FF" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#24D9FF"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#071820">DK</text>
+</svg>

--- a/icons/light/file-env.svg
+++ b/icons/light/file-env.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#66F29A" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#66F29A"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="4" font-weight="800" fill="#06200F">ENV</text>
+</svg>

--- a/icons/light/file-git.svg
+++ b/icons/light/file-git.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#FF4C6A" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FF4C6A"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#26070D">G</text>
+</svg>

--- a/icons/light/file-github.svg
+++ b/icons/light/file-github.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#9C7BFF" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#9C7BFF"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#111022">GH</text>
+</svg>

--- a/icons/light/file-go.svg
+++ b/icons/light/file-go.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#66F2E8" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#66F2E8"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#061C1A">GO</text>
+</svg>

--- a/icons/light/file-html.svg
+++ b/icons/light/file-html.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#FF7A45" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FF7A45"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#1B0D08">H5</text>
+</svg>

--- a/icons/light/file-js.svg
+++ b/icons/light/file-js.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#FFE05C" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FFE05C"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#1B1726">JS</text>
+</svg>

--- a/icons/light/file-json.svg
+++ b/icons/light/file-json.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#FF36B7" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FF36B7"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#240018">{}</text>
+</svg>

--- a/icons/light/file-license.svg
+++ b/icons/light/file-license.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#B8C8D8" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#B8C8D8"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="4" font-weight="800" fill="#202235">MIT</text>
+</svg>

--- a/icons/light/file-md.svg
+++ b/icons/light/file-md.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#E8EDF7" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#E8EDF7"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#202235">MD</text>
+</svg>

--- a/icons/light/file-package.svg
+++ b/icons/light/file-package.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#FF36B7" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FF36B7"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="4" font-weight="800" fill="#240018">PKG</text>
+</svg>

--- a/icons/light/file-python.svg
+++ b/icons/light/file-python.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#FFE05C" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FFE05C"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#15151F">PY</text>
+</svg>

--- a/icons/light/file-react.svg
+++ b/icons/light/file-react.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#9C7BFF" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#9C7BFF"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#111022">RX</text>
+</svg>

--- a/icons/light/file-readme.svg
+++ b/icons/light/file-readme.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#E8EDF7" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#E8EDF7"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#202235">RD</text>
+</svg>

--- a/icons/light/file-rust.svg
+++ b/icons/light/file-rust.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#FF7A45" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FF7A45"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#1C0C05">RS</text>
+</svg>

--- a/icons/light/file-shell.svg
+++ b/icons/light/file-shell.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#66F29A" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#66F29A"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#06200F">$_</text>
+</svg>

--- a/icons/light/file-ts.svg
+++ b/icons/light/file-ts.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#24D9FF" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#24D9FF"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#08141C">TS</text>
+</svg>

--- a/icons/light/file-yaml.svg
+++ b/icons/light/file-yaml.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="#FFFDF7"/>
+  <path d="M9 2v3h3" fill="#FFB15E" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="#007E8C" stroke-opacity=".42"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="#FF36B7" opacity=".28"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="#FFB15E"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="5" font-weight="800" fill="#241406">Y</text>
+</svg>

--- a/icons/pixels-to-punk-cyber-icon-theme.json
+++ b/icons/pixels-to-punk-cyber-icon-theme.json
@@ -14,6 +14,66 @@
     },
     "_root_folder_open": {
       "iconPath": "./root-folder-open.svg"
+    },
+    "_file_js": {
+      "iconPath": "./file-js.svg"
+    },
+    "_file_ts": {
+      "iconPath": "./file-ts.svg"
+    },
+    "_file_react": {
+      "iconPath": "./file-react.svg"
+    },
+    "_file_html": {
+      "iconPath": "./file-html.svg"
+    },
+    "_file_css": {
+      "iconPath": "./file-css.svg"
+    },
+    "_file_json": {
+      "iconPath": "./file-json.svg"
+    },
+    "_file_md": {
+      "iconPath": "./file-md.svg"
+    },
+    "_file_shell": {
+      "iconPath": "./file-shell.svg"
+    },
+    "_file_git": {
+      "iconPath": "./file-git.svg"
+    },
+    "_file_docker": {
+      "iconPath": "./file-docker.svg"
+    },
+    "_file_yaml": {
+      "iconPath": "./file-yaml.svg"
+    },
+    "_file_python": {
+      "iconPath": "./file-python.svg"
+    },
+    "_file_rust": {
+      "iconPath": "./file-rust.svg"
+    },
+    "_file_go": {
+      "iconPath": "./file-go.svg"
+    },
+    "_file_env": {
+      "iconPath": "./file-env.svg"
+    },
+    "_file_config": {
+      "iconPath": "./file-config.svg"
+    },
+    "_file_package": {
+      "iconPath": "./file-package.svg"
+    },
+    "_file_readme": {
+      "iconPath": "./file-readme.svg"
+    },
+    "_file_license": {
+      "iconPath": "./file-license.svg"
+    },
+    "_file_github": {
+      "iconPath": "./file-github.svg"
     }
   },
   "file": "_file",
@@ -22,7 +82,102 @@
   "rootFolder": "_root_folder",
   "rootFolderExpanded": "_root_folder_open",
   "hidesExplorerArrows": false,
-  "languageIds": {},
-  "fileExtensions": {},
-  "fileNames": {}
+  "languageIds": {
+    "javascript": "_file_js",
+    "javascriptreact": "_file_react",
+    "typescript": "_file_ts",
+    "typescriptreact": "_file_react",
+    "html": "_file_html",
+    "css": "_file_css",
+    "scss": "_file_css",
+    "less": "_file_css",
+    "json": "_file_json",
+    "jsonc": "_file_json",
+    "markdown": "_file_md",
+    "shellscript": "_file_shell",
+    "dockerfile": "_file_docker",
+    "yaml": "_file_yaml",
+    "python": "_file_python",
+    "rust": "_file_rust",
+    "go": "_file_go",
+    "gitignore": "_file_git"
+  },
+  "fileExtensions": {
+    "js": "_file_js",
+    "cjs": "_file_js",
+    "mjs": "_file_js",
+    "jsx": "_file_react",
+    "ts": "_file_ts",
+    "mts": "_file_ts",
+    "cts": "_file_ts",
+    "tsx": "_file_react",
+    "html": "_file_html",
+    "htm": "_file_html",
+    "css": "_file_css",
+    "scss": "_file_css",
+    "sass": "_file_css",
+    "less": "_file_css",
+    "json": "_file_json",
+    "jsonc": "_file_json",
+    "md": "_file_md",
+    "markdown": "_file_md",
+    "sh": "_file_shell",
+    "bash": "_file_shell",
+    "zsh": "_file_shell",
+    "fish": "_file_shell",
+    "yml": "_file_yaml",
+    "yaml": "_file_yaml",
+    "py": "_file_python",
+    "rs": "_file_rust",
+    "go": "_file_go",
+    "env": "_file_env",
+    "toml": "_file_config",
+    "ini": "_file_config",
+    "config": "_file_config",
+    "lock": "_file_package"
+  },
+  "fileNames": {
+    ".env": "_file_env",
+    ".env.local": "_file_env",
+    ".env.example": "_file_env",
+    ".env.development": "_file_env",
+    ".env.production": "_file_env",
+    ".env.test": "_file_env",
+    ".gitignore": "_file_git",
+    ".gitattributes": "_file_git",
+    ".gitmodules": "_file_git",
+    "Dockerfile": "_file_docker",
+    "dockerfile": "_file_docker",
+    "docker-compose.yml": "_file_docker",
+    "docker-compose.yaml": "_file_docker",
+    "package.json": "_file_package",
+    "package-lock.json": "_file_package",
+    "npm-shrinkwrap.json": "_file_package",
+    "pnpm-lock.yaml": "_file_package",
+    "yarn.lock": "_file_package",
+    "bun.lockb": "_file_package",
+    "README": "_file_readme",
+    "README.md": "_file_readme",
+    "readme.md": "_file_readme",
+    "LICENSE": "_file_license",
+    "LICENSE.md": "_file_license",
+    "LICENSE.txt": "_file_license",
+    "license": "_file_license",
+    "license.md": "_file_license",
+    "license.txt": "_file_license",
+    "tsconfig.json": "_file_ts",
+    "jsconfig.json": "_file_js",
+    "vite.config.js": "_file_config",
+    "vite.config.ts": "_file_config",
+    "vitest.config.js": "_file_config",
+    "vitest.config.ts": "_file_config",
+    "eslint.config.js": "_file_config",
+    "eslint.config.mjs": "_file_config",
+    "prettier.config.js": "_file_config",
+    ".prettierrc": "_file_config",
+    ".eslintrc": "_file_config",
+    ".github": "_file_github",
+    "dependabot.yml": "_file_github",
+    "dependabot.yaml": "_file_github"
+  }
 }

--- a/icons/pixels-to-punk-cyber-light-icon-theme.json
+++ b/icons/pixels-to-punk-cyber-light-icon-theme.json
@@ -14,6 +14,66 @@
     },
     "_root_folder_open_light": {
       "iconPath": "./light/root-folder-open.svg"
+    },
+    "_file_js_light": {
+      "iconPath": "./light/file-js.svg"
+    },
+    "_file_ts_light": {
+      "iconPath": "./light/file-ts.svg"
+    },
+    "_file_react_light": {
+      "iconPath": "./light/file-react.svg"
+    },
+    "_file_html_light": {
+      "iconPath": "./light/file-html.svg"
+    },
+    "_file_css_light": {
+      "iconPath": "./light/file-css.svg"
+    },
+    "_file_json_light": {
+      "iconPath": "./light/file-json.svg"
+    },
+    "_file_md_light": {
+      "iconPath": "./light/file-md.svg"
+    },
+    "_file_shell_light": {
+      "iconPath": "./light/file-shell.svg"
+    },
+    "_file_git_light": {
+      "iconPath": "./light/file-git.svg"
+    },
+    "_file_docker_light": {
+      "iconPath": "./light/file-docker.svg"
+    },
+    "_file_yaml_light": {
+      "iconPath": "./light/file-yaml.svg"
+    },
+    "_file_python_light": {
+      "iconPath": "./light/file-python.svg"
+    },
+    "_file_rust_light": {
+      "iconPath": "./light/file-rust.svg"
+    },
+    "_file_go_light": {
+      "iconPath": "./light/file-go.svg"
+    },
+    "_file_env_light": {
+      "iconPath": "./light/file-env.svg"
+    },
+    "_file_config_light": {
+      "iconPath": "./light/file-config.svg"
+    },
+    "_file_package_light": {
+      "iconPath": "./light/file-package.svg"
+    },
+    "_file_readme_light": {
+      "iconPath": "./light/file-readme.svg"
+    },
+    "_file_license_light": {
+      "iconPath": "./light/file-license.svg"
+    },
+    "_file_github_light": {
+      "iconPath": "./light/file-github.svg"
     }
   },
   "file": "_file_light",
@@ -22,7 +82,102 @@
   "rootFolder": "_root_folder_light",
   "rootFolderExpanded": "_root_folder_open_light",
   "hidesExplorerArrows": false,
-  "languageIds": {},
-  "fileExtensions": {},
-  "fileNames": {}
+  "languageIds": {
+    "javascript": "_file_js_light",
+    "javascriptreact": "_file_react_light",
+    "typescript": "_file_ts_light",
+    "typescriptreact": "_file_react_light",
+    "html": "_file_html_light",
+    "css": "_file_css_light",
+    "scss": "_file_css_light",
+    "less": "_file_css_light",
+    "json": "_file_json_light",
+    "jsonc": "_file_json_light",
+    "markdown": "_file_md_light",
+    "shellscript": "_file_shell_light",
+    "dockerfile": "_file_docker_light",
+    "yaml": "_file_yaml_light",
+    "python": "_file_python_light",
+    "rust": "_file_rust_light",
+    "go": "_file_go_light",
+    "gitignore": "_file_git_light"
+  },
+  "fileExtensions": {
+    "js": "_file_js_light",
+    "cjs": "_file_js_light",
+    "mjs": "_file_js_light",
+    "jsx": "_file_react_light",
+    "ts": "_file_ts_light",
+    "mts": "_file_ts_light",
+    "cts": "_file_ts_light",
+    "tsx": "_file_react_light",
+    "html": "_file_html_light",
+    "htm": "_file_html_light",
+    "css": "_file_css_light",
+    "scss": "_file_css_light",
+    "sass": "_file_css_light",
+    "less": "_file_css_light",
+    "json": "_file_json_light",
+    "jsonc": "_file_json_light",
+    "md": "_file_md_light",
+    "markdown": "_file_md_light",
+    "sh": "_file_shell_light",
+    "bash": "_file_shell_light",
+    "zsh": "_file_shell_light",
+    "fish": "_file_shell_light",
+    "yml": "_file_yaml_light",
+    "yaml": "_file_yaml_light",
+    "py": "_file_python_light",
+    "rs": "_file_rust_light",
+    "go": "_file_go_light",
+    "env": "_file_env_light",
+    "toml": "_file_config_light",
+    "ini": "_file_config_light",
+    "config": "_file_config_light",
+    "lock": "_file_package_light"
+  },
+  "fileNames": {
+    ".env": "_file_env_light",
+    ".env.local": "_file_env_light",
+    ".env.example": "_file_env_light",
+    ".env.development": "_file_env_light",
+    ".env.production": "_file_env_light",
+    ".env.test": "_file_env_light",
+    ".gitignore": "_file_git_light",
+    ".gitattributes": "_file_git_light",
+    ".gitmodules": "_file_git_light",
+    "Dockerfile": "_file_docker_light",
+    "dockerfile": "_file_docker_light",
+    "docker-compose.yml": "_file_docker_light",
+    "docker-compose.yaml": "_file_docker_light",
+    "package.json": "_file_package_light",
+    "package-lock.json": "_file_package_light",
+    "npm-shrinkwrap.json": "_file_package_light",
+    "pnpm-lock.yaml": "_file_package_light",
+    "yarn.lock": "_file_package_light",
+    "bun.lockb": "_file_package_light",
+    "README": "_file_readme_light",
+    "README.md": "_file_readme_light",
+    "readme.md": "_file_readme_light",
+    "LICENSE": "_file_license_light",
+    "LICENSE.md": "_file_license_light",
+    "LICENSE.txt": "_file_license_light",
+    "license": "_file_license_light",
+    "license.md": "_file_license_light",
+    "license.txt": "_file_license_light",
+    "tsconfig.json": "_file_ts_light",
+    "jsconfig.json": "_file_js_light",
+    "vite.config.js": "_file_config_light",
+    "vite.config.ts": "_file_config_light",
+    "vitest.config.js": "_file_config_light",
+    "vitest.config.ts": "_file_config_light",
+    "eslint.config.js": "_file_config_light",
+    "eslint.config.mjs": "_file_config_light",
+    "prettier.config.js": "_file_config_light",
+    ".prettierrc": "_file_config_light",
+    ".eslintrc": "_file_config_light",
+    ".github": "_file_github_light",
+    "dependabot.yml": "_file_github_light",
+    "dependabot.yaml": "_file_github_light"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules pixels-to-punk-cyber-*.vsix",
+    "build:file-icons": "node scripts/build-file-icons.js",
     "demo:terminal-colors": "node scripts/terminal-colors.js",
     "package": "npx --no-install vsce package --allow-missing-repository",
     "install:vsix": "code --install-extension pixels-to-punk-cyber-1.0.3.vsix --force"

--- a/scripts/build-file-icons.js
+++ b/scripts/build-file-icons.js
@@ -1,0 +1,186 @@
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const iconsDir = path.join(root, "icons");
+const lightIconsDir = path.join(iconsDir, "light");
+
+const iconSpecs = [
+  { id: "js", label: "JS", fill: "#FFE05C", ink: "#1B1726" },
+  { id: "ts", label: "TS", fill: "#24D9FF", ink: "#08141C" },
+  { id: "react", label: "RX", fill: "#9C7BFF", ink: "#111022" },
+  { id: "html", label: "H5", fill: "#FF7A45", ink: "#1B0D08" },
+  { id: "css", label: "CSS", fill: "#5EA8FF", ink: "#08111E", small: true },
+  { id: "json", label: "{}", fill: "#FF36B7", ink: "#240018" },
+  { id: "md", label: "MD", fill: "#E8EDF7", ink: "#202235" },
+  { id: "shell", label: "$_", fill: "#66F29A", ink: "#06200F" },
+  { id: "git", label: "G", fill: "#FF4C6A", ink: "#26070D" },
+  { id: "docker", label: "DK", fill: "#24D9FF", ink: "#071820" },
+  { id: "yaml", label: "Y", fill: "#FFB15E", ink: "#241406" },
+  { id: "python", label: "PY", fill: "#FFE05C", ink: "#15151F" },
+  { id: "rust", label: "RS", fill: "#FF7A45", ink: "#1C0C05" },
+  { id: "go", label: "GO", fill: "#66F2E8", ink: "#061C1A" },
+  { id: "env", label: "ENV", fill: "#66F29A", ink: "#06200F", small: true },
+  { id: "config", label: "*", fill: "#A5A8C4", ink: "#101019" },
+  { id: "package", label: "PKG", fill: "#FF36B7", ink: "#240018", small: true },
+  { id: "readme", label: "RD", fill: "#E8EDF7", ink: "#202235" },
+  { id: "license", label: "MIT", fill: "#B8C8D8", ink: "#202235", small: true },
+  { id: "github", label: "GH", fill: "#9C7BFF", ink: "#111022" }
+];
+
+const languageIds = {
+  javascript: "_file_js",
+  javascriptreact: "_file_react",
+  typescript: "_file_ts",
+  typescriptreact: "_file_react",
+  html: "_file_html",
+  css: "_file_css",
+  scss: "_file_css",
+  less: "_file_css",
+  json: "_file_json",
+  jsonc: "_file_json",
+  markdown: "_file_md",
+  shellscript: "_file_shell",
+  dockerfile: "_file_docker",
+  yaml: "_file_yaml",
+  python: "_file_python",
+  rust: "_file_rust",
+  go: "_file_go",
+  gitignore: "_file_git"
+};
+
+const fileExtensions = {
+  js: "_file_js",
+  cjs: "_file_js",
+  mjs: "_file_js",
+  jsx: "_file_react",
+  ts: "_file_ts",
+  mts: "_file_ts",
+  cts: "_file_ts",
+  tsx: "_file_react",
+  html: "_file_html",
+  htm: "_file_html",
+  css: "_file_css",
+  scss: "_file_css",
+  sass: "_file_css",
+  less: "_file_css",
+  json: "_file_json",
+  jsonc: "_file_json",
+  md: "_file_md",
+  markdown: "_file_md",
+  sh: "_file_shell",
+  bash: "_file_shell",
+  zsh: "_file_shell",
+  fish: "_file_shell",
+  yml: "_file_yaml",
+  yaml: "_file_yaml",
+  py: "_file_python",
+  rs: "_file_rust",
+  go: "_file_go",
+  env: "_file_env",
+  toml: "_file_config",
+  ini: "_file_config",
+  config: "_file_config",
+  lock: "_file_package"
+};
+
+const fileNames = {
+  ".env": "_file_env",
+  ".env.local": "_file_env",
+  ".env.example": "_file_env",
+  ".env.development": "_file_env",
+  ".env.production": "_file_env",
+  ".env.test": "_file_env",
+  ".gitignore": "_file_git",
+  ".gitattributes": "_file_git",
+  ".gitmodules": "_file_git",
+  "Dockerfile": "_file_docker",
+  "dockerfile": "_file_docker",
+  "docker-compose.yml": "_file_docker",
+  "docker-compose.yaml": "_file_docker",
+  "package.json": "_file_package",
+  "package-lock.json": "_file_package",
+  "npm-shrinkwrap.json": "_file_package",
+  "pnpm-lock.yaml": "_file_package",
+  "yarn.lock": "_file_package",
+  "bun.lockb": "_file_package",
+  "README": "_file_readme",
+  "README.md": "_file_readme",
+  "readme.md": "_file_readme",
+  "LICENSE": "_file_license",
+  "LICENSE.md": "_file_license",
+  "LICENSE.txt": "_file_license",
+  "license": "_file_license",
+  "license.md": "_file_license",
+  "license.txt": "_file_license",
+  "tsconfig.json": "_file_ts",
+  "jsconfig.json": "_file_js",
+  "vite.config.js": "_file_config",
+  "vite.config.ts": "_file_config",
+  "vitest.config.js": "_file_config",
+  "vitest.config.ts": "_file_config",
+  "eslint.config.js": "_file_config",
+  "eslint.config.mjs": "_file_config",
+  "prettier.config.js": "_file_config",
+  ".prettierrc": "_file_config",
+  ".eslintrc": "_file_config",
+  ".github": "_file_github",
+  "dependabot.yml": "_file_github",
+  "dependabot.yaml": "_file_github"
+};
+
+function svg({ label, fill, ink, small }, light = false) {
+  const paper = light ? "#FFFDF7" : "#101019";
+  const outline = light ? "#007E8C" : "#24D9FF";
+  const shadow = light ? "#FF36B7" : "#FF36B7";
+  const fontSize = small ? 4 : label.length > 2 ? 4.4 : 5;
+
+  return `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M4 2h5l3 3v9H4V2Z" fill="${paper}"/>
+  <path d="M9 2v3h3" fill="${fill}" opacity=".55"/>
+  <path d="M4 2h5l3 3v9H4V2Z" stroke="${outline}" stroke-opacity="${light ? ".42" : ".5"}"/>
+  <path d="M3.5 11.5 12 9.75v3.5L3.5 15v-3.5Z" fill="${shadow}" opacity="${light ? ".28" : ".38"}"/>
+  <rect x="3" y="6.5" width="10" height="5.75" rx="1.25" fill="${fill}"/>
+  <text x="8" y="10.75" text-anchor="middle" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="${fontSize}" font-weight="800" fill="${ink}">${label}</text>
+</svg>
+`;
+}
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function prefixedMappings(source, suffix) {
+  return Object.fromEntries(
+    Object.entries(source).map(([key, value]) => [key, `${value}${suffix}`])
+  );
+}
+
+function updateTheme(file, suffix, light = false) {
+  const theme = readJson(file);
+
+  for (const spec of iconSpecs) {
+    const id = `_file_${spec.id}${suffix}`;
+    theme.iconDefinitions[id] = {
+      iconPath: light ? `./light/file-${spec.id}.svg` : `./file-${spec.id}.svg`
+    };
+  }
+
+  theme.languageIds = prefixedMappings(languageIds, suffix);
+  theme.fileExtensions = prefixedMappings(fileExtensions, suffix);
+  theme.fileNames = prefixedMappings(fileNames, suffix);
+
+  writeJson(file, theme);
+}
+
+for (const spec of iconSpecs) {
+  fs.writeFileSync(path.join(iconsDir, `file-${spec.id}.svg`), svg(spec));
+  fs.writeFileSync(path.join(lightIconsDir, `file-${spec.id}.svg`), svg(spec, true));
+}
+
+updateTheme(path.join(iconsDir, "pixels-to-punk-cyber-icon-theme.json"), "", false);
+updateTheme(path.join(iconsDir, "pixels-to-punk-cyber-light-icon-theme.json"), "_light", true);


### PR DESCRIPTION
## What changed

Adds generated file-specific SVG icons for common languages and project files, including JavaScript, TypeScript, React, HTML, CSS, JSON, Markdown, shell scripts, Git files, Docker files, YAML, Python, Rust, Go, environment files, config files, package files, README files, license files, and GitHub-related files.

This also updates both Pixels to Punk icon theme manifests so dark and light icon themes use aligned icon mappings, and adds a small generator script so future icon additions happen in one place.

## Documentation

Splits the large README into three clearer docs:
- README.md is now the home landing page with the plain overview, feature list, theme list, eye-comfort notes, and links.
- QUICKSTART.md is the short grab-it-and-go install guide.
- DEV.md is the developer and maintainer guide with build, release, icon update, and theme-fit rules.

The docs are written in plain, kid-friendly language and keep the what/how/when/where guidance for new features.

## Validation

- npm run build:file-icons
- git diff --check
- npm run package

Closes #1