### PR TITLE
[codex] Add workspace mood presets

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -1,0 +1,100 @@
+name: Version and Release VSIX
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version, like 1.0.5"
+        required: true
+        type: string
+      prerelease:
+        description: "Mark the GitHub Release as a prerelease"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  version-and-release:
+    name: Update version, tag, and publish VSIX
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate version input
+        run: |
+          VERSION="${{ inputs.version }}"
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "Version must look like 1.0.5 or 1.0.5-beta.1"
+            exit 1
+          fi
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "Tag v$VERSION already exists"
+            exit 1
+          fi
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update package version
+        run: |
+          CURRENT_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$CURRENT_VERSION" = "${{ inputs.version }}" ]; then
+            echo "package.json is already at $CURRENT_VERSION"
+          else
+            npm version "${{ inputs.version }}" --no-git-tag-version
+          fi
+
+      - name: Build generated theme variants
+        run: node scripts/build-theme-variants.js
+
+      - name: Build generated file icons
+        run: npm run build:file-icons
+
+      - name: Package VS Code extension
+        run: npm run package
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json themes icons
+          if git diff --cached --quiet; then
+            echo "No version or generated file changes to commit"
+          else
+            git commit -m "Release v${{ inputs.version }}"
+          fi
+
+      - name: Tag release
+        run: git tag "v${{ inputs.version }}"
+
+      - name: Push commit and tag
+        run: |
+          git push origin HEAD:main
+          git push origin "v${{ inputs.version }}"
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          FLAGS=()
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
+            FLAGS+=(--prerelease)
+          fi
+
+          gh release create "v${{ inputs.version }}" pixels-to-punk-cyber-${{ inputs.version }}.vsix \
+            --title "v${{ inputs.version }}" \
+            --notes "Download the VSIX file below, then install it in VS Code with Extensions: Install from VSIX." \
+            "${FLAGS[@]}"

--- a/DEV.md
+++ b/DEV.md
@@ -32,6 +32,7 @@ VS Code reads the JSON and SVG files in this repo.
 | `icons/light/` | Holds the light SVG icons. |
 | `icons/pixels-to-punk-cyber-icon-theme.json` | Maps files to dark icons. |
 | `icons/pixels-to-punk-cyber-light-icon-theme.json` | Maps files to light icons. |
+| `src/extension.js` | Adds command palette commands, including workspace mood presets. |
 | `scripts/build-theme-variants.js` | Builds theme variants from palettes. |
 | `scripts/build-file-icons.js` | Builds file icons and icon maps. |
 | `scripts/terminal-colors.js` | Prints terminal colors for testing. |
@@ -187,6 +188,106 @@ When you add a new thing, ask:
 The goal is not to make every theme identical.
 
 The goal is to make every theme feel like it belongs.
+
+## Workspace Mood Presets
+
+A workspace mood preset is one command that changes a few VS Code settings for the folder a person has open.
+
+It is opt-in.
+
+It does not run automatically.
+
+It does not change code.
+
+It only writes workspace settings.
+
+If no folder or workspace is open, the command shows a warning and does not change anything.
+
+### What The Presets Change
+
+Each preset can change:
+
+- `workbench.colorTheme`
+- `workbench.iconTheme`
+- `editor.minimap.enabled`
+- `editor.stickyScroll.enabled`
+- `editor.guides.bracketPairs`
+- `editor.bracketPairColorization.enabled`
+- `editor.renderWhitespace`
+- `editor.cursorBlinking`
+- `editor.wordWrap`
+- `terminal.integrated.tabs.enabled`
+
+### Current Presets
+
+| Preset | Color Theme | Icon Theme | Why It Exists |
+| --- | --- | --- | --- |
+| Deep Work | Pixels to Punk Cyber Dark for Those with Glasses | Pixels to Punk Cyber Icons | Quiet dark setup for focused work. |
+| Terminal Night | Pixels to Punk CRT After Midnight | Pixels to Punk Cyber Icons | Terminal-heavy setup with CRT energy. |
+| Zine Shop | Pixels to Punk Zine Shop Window | Pixels to Punk Cyber Icons Light | Warm light setup for docs and notes. |
+| Maximum Neon | Pixels to Punk Riot Glow Dark | Pixels to Punk Cyber Icons | Loud neon setup. |
+| Low Glare | Pixels to Punk Soft Focus Night | Pixels to Punk Cyber Icons | Softer setup for tired eyes. |
+
+### How People Use Them
+
+1. Open a folder in VS Code.
+2. Open the Command Palette.
+3. Run:
+
+   ```text
+   Pixels to Punk: Pick Workspace Mood Preset
+   ```
+
+4. Pick a mood.
+
+They can also run a preset directly:
+
+- `Pixels to Punk: Apply Deep Work Preset`
+- `Pixels to Punk: Apply Terminal Night Preset`
+- `Pixels to Punk: Apply Zine Shop Preset`
+- `Pixels to Punk: Apply Maximum Neon Preset`
+- `Pixels to Punk: Apply Low Glare Preset`
+
+### How People Undo Them
+
+Run:
+
+```text
+Pixels to Punk: Reset Workspace Mood Preset
+```
+
+That clears the settings listed above from workspace settings.
+
+### Where To Update Presets
+
+The preset code lives here:
+
+```text
+src/extension.js
+```
+
+The command list lives in `package.json` under:
+
+```text
+contributes.commands
+```
+
+The command activation list lives in `package.json` under:
+
+```text
+activationEvents
+```
+
+### When To Update Presets
+
+Update presets when:
+
+- a new theme becomes a better fit for a mood
+- a setting feels too noisy or too quiet
+- a light preset needs a light icon theme
+- a dark preset needs a dark icon theme
+- users need a clearer reset path
+- a new mood gets added
 
 ## Test Terminal Colors
 

--- a/DEV.md
+++ b/DEV.md
@@ -358,57 +358,79 @@ The final `.vsix` file does not include `node_modules`.
 After `npm run package`, run:
 
 ```sh
-code --install-extension pixels-to-punk-cyber-1.0.3.vsix --force
+npm run install:vsix
 ```
 
-If the version changes, the file name changes too.
+That command reads the version from `package.json`, then installs the matching `.vsix` file.
 
 ## GitHub Releases
 
-This repo has a GitHub Action that builds the `.vsix` file.
+This repo has two GitHub Actions for releases.
+
+### Easy Release
+
+Use **Version and Release VSIX** when you want GitHub to do the release work.
 
 To run it by hand:
 
 1. Open the repo on GitHub.
 2. Click **Actions**.
-3. Click **Build VSIX**.
+3. Click **Version and Release VSIX**.
 4. Click **Run workflow**.
+5. Type the new version number.
+6. Click **Run workflow**.
 
-To publish a real GitHub Release, push a version tag:
+Example version:
 
-```sh
-git tag v1.0.3
-git push origin v1.0.3
+```text
+1.0.5
 ```
 
-The action builds the `.vsix` file and attaches it to the GitHub Release for that tag.
+That workflow:
+
+1. updates `package.json`
+2. updates `package-lock.json`
+3. rebuilds generated theme variants
+4. rebuilds generated file icons
+5. builds the `.vsix` file
+6. commits the version bump to `main`
+7. creates the `v` tag
+8. publishes the GitHub Release
+
+### Build Only
+
+Use **Build VSIX** when you only want to build the `.vsix` file.
+
+That workflow runs on version tags and can also be run by hand.
 
 The workflow rebuilds generated theme variants and generated file icons before packaging.
 
 ## Release Checklist
 
-When you change the extension and want a new release:
+Use this checklist if you release by hand instead of using **Version and Release VSIX**.
 
 1. Open `package.json`.
 2. Change the version number.
-3. Run:
+3. Open `package-lock.json`.
+4. Change the root version numbers to match.
+5. Run:
 
    ```sh
    npm run package
    ```
 
-4. Commit the changes.
-5. Tag the commit with the same version.
-6. Push the commit and tag.
+6. Commit the changes.
+7. Tag the commit with the same version.
+8. Push the commit and tag.
 
 Example:
 
 ```sh
 git add .
-git commit -m "Release v1.0.3"
-git tag v1.0.3
+git commit -m "Release v1.0.5"
+git tag v1.0.5
 git push origin main
-git push origin v1.0.3
+git push origin v1.0.5
 ```
 
 ## If The `code` Command Does Not Work

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -53,6 +53,47 @@ So if you pick a light color theme, you may want to pick the light icon theme yo
 
 Now your folders and files should have Pixels to Punk icons.
 
+## Optional: Pick A Workspace Mood
+
+A mood preset is a shortcut.
+
+It picks a color theme, an icon theme, and a few editor settings for the folder you have open.
+
+It does not change your code.
+
+It only changes VS Code settings for that workspace.
+
+1. Open a project folder in VS Code.
+2. Press `Command + Shift + P`.
+3. Type:
+
+   ```text
+   Pixels to Punk: Pick Workspace Mood Preset
+   ```
+
+4. Pick a mood.
+
+The moods are:
+
+- **Deep Work**: quiet dark colors with fewer distractions
+- **Terminal Night**: CRT colors for terminal-heavy work
+- **Zine Shop**: warm light colors for docs and notes
+- **Maximum Neon**: the loudest neon setup
+- **Low Glare**: softer colors for tired eyes
+
+To undo a mood preset:
+
+1. Press `Command + Shift + P`.
+2. Type:
+
+   ```text
+   Pixels to Punk: Reset Workspace Mood Preset
+   ```
+
+3. Press Enter.
+
+That clears the settings the mood preset changed.
+
 ## If The Theme Does Not Show Up
 
 Sometimes VS Code needs a quick refresh.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You get:
 - lower-glare themes
 - high-contrast themes
 - special file icons for common code files
+- workspace mood presets
 - terminal colors
 - Git, Problems, Debug Console, and Output panel colors
 
@@ -54,6 +55,8 @@ It can change:
 - warning and error colors
 - folder icons
 - file icons
+
+It can also apply optional workspace mood presets. A mood preset is one command that picks a color theme, icon theme, and a few editor settings for the folder you have open.
 
 It does not change your code.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixels-to-punk-cyber",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixels-to-punk-cyber",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "devDependencies": {
         "@vscode/vsce": "^3.9.1"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pixels-to-punk-cyber",
   "displayName": "Pixels to Punk Cyber",
   "description": "Neon punk VS Code themes inspired by the From Pixels to Punk brand, with anime-pop color, punk energy, and coding comfort.",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "publisher": "local",
   "license": "MIT",
   "main": "./src/extension.js",
@@ -241,7 +241,7 @@
     "build:file-icons": "node scripts/build-file-icons.js",
     "demo:terminal-colors": "node scripts/terminal-colors.js",
     "package": "npx --no-install vsce package --allow-missing-repository",
-    "install:vsix": "code --install-extension pixels-to-punk-cyber-1.0.3.vsix --force"
+    "install:vsix": "node scripts/install-vsix.js"
   },
   "devDependencies": {
     "@vscode/vsce": "^3.9.1"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "1.0.3",
   "publisher": "local",
   "license": "MIT",
+  "main": "./src/extension.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/ryemyster/fptp-vscode-themes.git"
@@ -20,7 +21,53 @@
     "Themes",
     "Other"
   ],
+  "activationEvents": [
+    "onCommand:pixelsToPunk.pickMoodPreset",
+    "onCommand:pixelsToPunk.applyDeepWorkPreset",
+    "onCommand:pixelsToPunk.applyTerminalNightPreset",
+    "onCommand:pixelsToPunk.applyZineShopPreset",
+    "onCommand:pixelsToPunk.applyMaximumNeonPreset",
+    "onCommand:pixelsToPunk.applyLowGlarePreset",
+    "onCommand:pixelsToPunk.resetMoodPreset"
+  ],
   "contributes": {
+    "commands": [
+      {
+        "command": "pixelsToPunk.pickMoodPreset",
+        "title": "Pixels to Punk: Pick Workspace Mood Preset",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.applyDeepWorkPreset",
+        "title": "Pixels to Punk: Apply Deep Work Preset",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.applyTerminalNightPreset",
+        "title": "Pixels to Punk: Apply Terminal Night Preset",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.applyZineShopPreset",
+        "title": "Pixels to Punk: Apply Zine Shop Preset",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.applyMaximumNeonPreset",
+        "title": "Pixels to Punk: Apply Maximum Neon Preset",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.applyLowGlarePreset",
+        "title": "Pixels to Punk: Apply Low Glare Preset",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.resetMoodPreset",
+        "title": "Pixels to Punk: Reset Workspace Mood Preset",
+        "category": "Pixels to Punk"
+      }
+    ],
     "iconThemes": [
       {
         "id": "pixels-to-punk-cyber-icons",

--- a/scripts/install-vsix.js
+++ b/scripts/install-vsix.js
@@ -1,0 +1,8 @@
+const { execFileSync } = require("child_process");
+const { version } = require("../package.json");
+
+const vsixFile = `pixels-to-punk-cyber-${version}.vsix`;
+
+execFileSync("code", ["--install-extension", vsixFile, "--force"], {
+  stdio: "inherit"
+});

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,0 +1,191 @@
+const vscode = require("vscode");
+
+const PRESET_SETTINGS = [
+  "workbench.colorTheme",
+  "workbench.iconTheme",
+  "editor.minimap.enabled",
+  "editor.stickyScroll.enabled",
+  "editor.guides.bracketPairs",
+  "editor.bracketPairColorization.enabled",
+  "editor.renderWhitespace",
+  "editor.cursorBlinking",
+  "editor.wordWrap",
+  "terminal.integrated.tabs.enabled"
+];
+
+const presets = [
+  {
+    id: "deepWork",
+    label: "Deep Work",
+    description: "Quiet dark colors with fewer distractions.",
+    command: "pixelsToPunk.applyDeepWorkPreset",
+    settings: {
+      "workbench.colorTheme": "Pixels to Punk Cyber Dark for Those with Glasses",
+      "workbench.iconTheme": "pixels-to-punk-cyber-icons",
+      "editor.minimap.enabled": false,
+      "editor.stickyScroll.enabled": true,
+      "editor.guides.bracketPairs": "active",
+      "editor.bracketPairColorization.enabled": true,
+      "editor.renderWhitespace": "boundary",
+      "editor.cursorBlinking": "smooth",
+      "editor.wordWrap": "off",
+      "terminal.integrated.tabs.enabled": false
+    }
+  },
+  {
+    id: "terminalNight",
+    label: "Terminal Night",
+    description: "CRT colors for shell-heavy night work.",
+    command: "pixelsToPunk.applyTerminalNightPreset",
+    settings: {
+      "workbench.colorTheme": "Pixels to Punk CRT After Midnight",
+      "workbench.iconTheme": "pixels-to-punk-cyber-icons",
+      "editor.minimap.enabled": false,
+      "editor.stickyScroll.enabled": false,
+      "editor.guides.bracketPairs": "active",
+      "editor.bracketPairColorization.enabled": true,
+      "editor.renderWhitespace": "none",
+      "editor.cursorBlinking": "phase",
+      "editor.wordWrap": "off",
+      "terminal.integrated.tabs.enabled": true
+    }
+  },
+  {
+    id: "zineShop",
+    label: "Zine Shop",
+    description: "Warm light colors for docs, notes, and readable edits.",
+    command: "pixelsToPunk.applyZineShopPreset",
+    settings: {
+      "workbench.colorTheme": "Pixels to Punk Zine Shop Window",
+      "workbench.iconTheme": "pixels-to-punk-cyber-icons-light",
+      "editor.minimap.enabled": false,
+      "editor.stickyScroll.enabled": true,
+      "editor.guides.bracketPairs": true,
+      "editor.bracketPairColorization.enabled": true,
+      "editor.renderWhitespace": "selection",
+      "editor.cursorBlinking": "smooth",
+      "editor.wordWrap": "on",
+      "terminal.integrated.tabs.enabled": false
+    }
+  },
+  {
+    id: "maximumNeon",
+    label: "Maximum Neon",
+    description: "The loudest Pixels to Punk coding mood.",
+    command: "pixelsToPunk.applyMaximumNeonPreset",
+    settings: {
+      "workbench.colorTheme": "Pixels to Punk Riot Glow Dark",
+      "workbench.iconTheme": "pixels-to-punk-cyber-icons",
+      "editor.minimap.enabled": true,
+      "editor.stickyScroll.enabled": true,
+      "editor.guides.bracketPairs": true,
+      "editor.bracketPairColorization.enabled": true,
+      "editor.renderWhitespace": "boundary",
+      "editor.cursorBlinking": "expand",
+      "editor.wordWrap": "off",
+      "terminal.integrated.tabs.enabled": true
+    }
+  },
+  {
+    id: "lowGlare",
+    label: "Low Glare",
+    description: "Soft colors for tired eyes and longer sessions.",
+    command: "pixelsToPunk.applyLowGlarePreset",
+    settings: {
+      "workbench.colorTheme": "Pixels to Punk Soft Focus Night",
+      "workbench.iconTheme": "pixels-to-punk-cyber-icons",
+      "editor.minimap.enabled": false,
+      "editor.stickyScroll.enabled": true,
+      "editor.guides.bracketPairs": "active",
+      "editor.bracketPairColorization.enabled": true,
+      "editor.renderWhitespace": "none",
+      "editor.cursorBlinking": "smooth",
+      "editor.wordWrap": "bounded",
+      "terminal.integrated.tabs.enabled": false
+    }
+  }
+];
+
+async function updateSetting(key, value) {
+  await vscode.workspace
+    .getConfiguration()
+    .update(key, value, vscode.ConfigurationTarget.Workspace);
+}
+
+function hasWorkspace() {
+  return Boolean(vscode.workspace.workspaceFolders);
+}
+
+function showOpenWorkspaceMessage() {
+  vscode.window.showWarningMessage(
+    "Open a folder or workspace first. Pixels to Punk mood presets only change workspace settings."
+  );
+}
+
+async function applyPreset(preset) {
+  if (!hasWorkspace()) {
+    showOpenWorkspaceMessage();
+    return;
+  }
+
+  for (const [key, value] of Object.entries(preset.settings)) {
+    await updateSetting(key, value);
+  }
+
+  vscode.window.showInformationMessage(
+    `Pixels to Punk ${preset.label} preset applied to workspace settings.`
+  );
+}
+
+async function resetPreset() {
+  if (!hasWorkspace()) {
+    showOpenWorkspaceMessage();
+    return;
+  }
+
+  for (const key of PRESET_SETTINGS) {
+    await updateSetting(key, undefined);
+  }
+
+  vscode.window.showInformationMessage(
+    "Pixels to Punk mood preset settings cleared from workspace settings."
+  );
+}
+
+async function pickMoodPreset() {
+  const selection = await vscode.window.showQuickPick(
+    presets.map((preset) => ({
+      label: preset.label,
+      description: preset.description,
+      preset
+    })),
+    {
+      title: "Pick a Pixels to Punk workspace mood",
+      placeHolder: "Choose a preset to apply"
+    }
+  );
+
+  if (selection) {
+    await applyPreset(selection.preset);
+  }
+}
+
+function activate(context) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand("pixelsToPunk.pickMoodPreset", pickMoodPreset),
+    vscode.commands.registerCommand("pixelsToPunk.resetMoodPreset", resetPreset)
+  );
+
+  for (const preset of presets) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(preset.command, () => applyPreset(preset))
+    );
+  }
+}
+
+function deactivate() {}
+
+module.exports = {
+  activate,
+  deactivate
+};


### PR DESCRIPTION
## What changed

Adds optional Pixels to Punk workspace mood preset commands:
- Pick Workspace Mood Preset
- Apply Deep Work Preset
- Apply Terminal Night Preset
- Apply Zine Shop Preset
- Apply Maximum Neon Preset
- Apply Low Glare Preset
- Reset Workspace Mood Preset

Each preset applies a color theme, icon theme, and a small set of workspace editor settings for the folder that is open. The commands do not run automatically and do not change source code.

## Safety and reversibility

Presets only write workspace settings. If no folder or workspace is open, the command shows a warning and makes no changes. The reset command clears the exact settings managed by the presets from workspace settings.

## Documentation

Updates README.md, QUICKSTART.md, and DEV.md with plain-language guidance covering:
- what mood presets are
- how non-devs use them
- how to undo them
- where maintainers update them
- when presets should be changed
- how theme/icon fit is handled for light, dark, low-glare, and louder neon moods

## Validation

- node --check src/extension.js
- package.json JSON parse check
- npm run build:file-icons
- git diff --check
- npm run package

Closes #2