### PR TITLE
[codex] Automate releases on main merges

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -1,24 +1,28 @@
 name: Version and Release VSIX
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "package.json"
+      - "package-lock.json"
+      - "themes/**"
+      - "icons/**"
+      - "src/**"
+      - "scripts/**"
+      - "README.md"
+      - "QUICKSTART.md"
+      - "DEV.md"
+      - ".github/workflows/version-and-release.yml"
   workflow_dispatch:
-    inputs:
-      version:
-        description: "Release version, like 1.0.5"
-        required: true
-        type: string
-      prerelease:
-        description: "Mark the GitHub Release as a prerelease"
-        required: true
-        default: false
-        type: boolean
 
 permissions:
   contents: write
 
 jobs:
-  version-and-release:
-    name: Update version, tag, and publish VSIX
+  release:
+    name: Tag and publish package version
     runs-on: ubuntu-latest
 
     steps:
@@ -27,74 +31,75 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate version input
+      - name: Read package version
+        id: package
         run: |
-          VERSION="${{ inputs.version }}"
+          VERSION="$(node -p "require('./package.json').version")"
           if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
-            echo "Version must look like 1.0.5 or 1.0.5-beta.1"
+            echo "package.json version must look like 1.0.5 or 1.0.5-beta.1"
             exit 1
           fi
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "Tag v$VERSION already exists"
-            exit 1
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release already exists
+        id: existing_release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.package.outputs.version }}"
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release v$VERSION already exists. Nothing to publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set up Node.js
+        if: steps.existing_release.outputs.exists == 'false'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
 
       - name: Install dependencies
+        if: steps.existing_release.outputs.exists == 'false'
         run: npm ci
 
-      - name: Update package version
-        run: |
-          CURRENT_VERSION="$(node -p "require('./package.json').version")"
-          if [ "$CURRENT_VERSION" = "${{ inputs.version }}" ]; then
-            echo "package.json is already at $CURRENT_VERSION"
-          else
-            npm version "${{ inputs.version }}" --no-git-tag-version
-          fi
-
       - name: Build generated theme variants
+        if: steps.existing_release.outputs.exists == 'false'
         run: node scripts/build-theme-variants.js
 
       - name: Build generated file icons
+        if: steps.existing_release.outputs.exists == 'false'
         run: npm run build:file-icons
 
       - name: Package VS Code extension
+        if: steps.existing_release.outputs.exists == 'false'
         run: npm run package
 
-      - name: Commit version bump
+      - name: Check generated files
+        if: steps.existing_release.outputs.exists == 'false'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json themes icons
-          if git diff --cached --quiet; then
-            echo "No version or generated file changes to commit"
-          else
-            git commit -m "Release v${{ inputs.version }}"
+          if ! git diff --quiet; then
+            echo "Generated files changed during release. Run the generators locally and commit the results."
+            git diff --stat
+            exit 1
           fi
 
       - name: Tag release
-        run: git tag "v${{ inputs.version }}"
+        if: steps.existing_release.outputs.exists == 'false'
+        run: git tag "v${{ steps.package.outputs.version }}"
 
-      - name: Push commit and tag
-        run: |
-          git push origin HEAD:main
-          git push origin "v${{ inputs.version }}"
+      - name: Push tag
+        if: steps.existing_release.outputs.exists == 'false'
+        run: git push origin "v${{ steps.package.outputs.version }}"
 
       - name: Publish GitHub release
+        if: steps.existing_release.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          FLAGS=()
-          if [ "${{ inputs.prerelease }}" = "true" ]; then
-            FLAGS+=(--prerelease)
-          fi
-
-          gh release create "v${{ inputs.version }}" pixels-to-punk-cyber-${{ inputs.version }}.vsix \
-            --title "v${{ inputs.version }}" \
-            --notes "Download the VSIX file below, then install it in VS Code with Extensions: Install from VSIX." \
-            "${FLAGS[@]}"
+          VERSION="${{ steps.package.outputs.version }}"
+          gh release create "v$VERSION" "pixels-to-punk-cyber-$VERSION.vsix" \
+            --title "v$VERSION" \
+            --notes "Download the VSIX file below, then install it in VS Code with Extensions: Install from VSIX."

--- a/DEV.md
+++ b/DEV.md
@@ -365,37 +365,33 @@ That command reads the version from `package.json`, then installs the matching `
 
 ## GitHub Releases
 
-This repo has two GitHub Actions for releases.
+This repo releases from `main`.
 
-### Easy Release
+When a PR is merged into `main`, **Version and Release VSIX** reads the version in `package.json`.
 
-Use **Version and Release VSIX** when you want GitHub to do the release work.
+If that version does not have a GitHub Release yet, the workflow:
 
-To run it by hand:
+1. rebuilds generated theme variants
+2. rebuilds generated file icons
+3. builds the `.vsix` file
+4. creates the `v` tag
+5. publishes the GitHub Release
 
-1. Open the repo on GitHub.
-2. Click **Actions**.
-3. Click **Version and Release VSIX**.
-4. Click **Run workflow**.
-5. Type the new version number.
-6. Click **Run workflow**.
-
-Example version:
+Example:
 
 ```text
 1.0.5
 ```
 
-That workflow:
+That becomes:
 
-1. updates `package.json`
-2. updates `package-lock.json`
-3. rebuilds generated theme variants
-4. rebuilds generated file icons
-5. builds the `.vsix` file
-6. commits the version bump to `main`
-7. creates the `v` tag
-8. publishes the GitHub Release
+```text
+v1.0.5
+```
+
+If that release already exists, the workflow exits without publishing another one.
+
+You can also run **Version and Release VSIX** by hand from the GitHub Actions page. The manual run uses the version already in `package.json`.
 
 ### Build Only
 
@@ -407,30 +403,30 @@ The workflow rebuilds generated theme variants and generated file icons before p
 
 ## Release Checklist
 
-Use this checklist if you release by hand instead of using **Version and Release VSIX**.
+Use this checklist in a feature PR when the change should create a new release after merge.
 
 1. Open `package.json`.
 2. Change the version number.
 3. Open `package-lock.json`.
 4. Change the root version numbers to match.
-5. Run:
+5. Run the normal checks:
 
    ```sh
+   npm run build:file-icons
    npm run package
    ```
 
 6. Commit the changes.
-7. Tag the commit with the same version.
-8. Push the commit and tag.
+7. Open a PR.
+8. Merge the PR into `main`.
+9. Wait for **Version and Release VSIX** to publish the release.
 
 Example:
 
 ```sh
 git add .
-git commit -m "Release v1.0.5"
-git tag v1.0.5
-git push origin main
-git push origin v1.0.5
+git commit -m "Bump release to v1.0.5"
+git push
 ```
 
 ## If The `code` Command Does Not Work


### PR DESCRIPTION
## What changed

Updates **Version and Release VSIX** so merging a PR into `main` becomes the release trigger.

The workflow now:
- runs on pushes to `main` for package, source, docs, theme, icon, script, and workflow changes
- reads the release version from `package.json`
- skips publishing if that GitHub Release already exists
- installs dependencies
- rebuilds generated theme variants
- rebuilds generated file icons
- packages the VSIX
- fails if generators change files that were not committed
- creates and pushes the `vX.Y.Z` tag
- publishes the GitHub Release with the matching VSIX

It can still be run manually, but manual runs now use the version already committed in `package.json`.

## Documentation

Updates `DEV.md` so the release checklist says to bump package versions in the PR, merge to `main`, then let the action tag and publish.

## Validation

- package/package-lock JSON parse
- node --check src/extension.js
- node --check scripts/install-vsix.js
- npm run build:file-icons
- npm run package
- git diff --check