### PR TITLE
[codex] Add optional time-of-day theme switching

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -32,7 +32,7 @@ VS Code reads the JSON and SVG files in this repo.
 | `icons/light/` | Holds the light SVG icons. |
 | `icons/pixels-to-punk-cyber-icon-theme.json` | Maps files to dark icons. |
 | `icons/pixels-to-punk-cyber-light-icon-theme.json` | Maps files to light icons. |
-| `src/extension.js` | Adds command palette commands, including workspace mood presets. |
+| `src/extension.js` | Adds command palette commands, including workspace mood presets and time-of-day switching. |
 | `scripts/build-theme-variants.js` | Builds theme variants from palettes. |
 | `scripts/build-file-icons.js` | Builds file icons and icon maps. |
 | `scripts/terminal-colors.js` | Prints terminal colors for testing. |
@@ -289,6 +289,114 @@ Update presets when:
 - users need a clearer reset path
 - a new mood gets added
 
+## Time-Of-Day Theme Switching
+
+Time-of-day switching picks a theme based on the current hour.
+
+It is opt-in.
+
+It does not run automatically until a person turns it on.
+
+It does not change code.
+
+It writes workspace settings only.
+
+If no folder or workspace is open, the command shows a warning and does not change anything.
+
+### What It Changes
+
+Time-of-day switching changes:
+
+- `workbench.colorTheme`
+- `workbench.iconTheme`
+
+It also reads these Pixels to Punk settings:
+
+- `pixelsToPunk.timeOfDay.enabled`
+- `pixelsToPunk.timeOfDay.dayStartHour`
+- `pixelsToPunk.timeOfDay.eveningStartHour`
+- `pixelsToPunk.timeOfDay.nightStartHour`
+- `pixelsToPunk.timeOfDay.dayTheme`
+- `pixelsToPunk.timeOfDay.eveningTheme`
+- `pixelsToPunk.timeOfDay.nightTheme`
+- `pixelsToPunk.timeOfDay.dayIconTheme`
+- `pixelsToPunk.timeOfDay.eveningIconTheme`
+- `pixelsToPunk.timeOfDay.nightIconTheme`
+
+### Default Pairings
+
+| Time | Starts | Color Theme | Icon Theme |
+| --- | --- | --- | --- |
+| Day | 7 AM | Pixels to Punk Soft Focus Day | Pixels to Punk Cyber Icons Light |
+| Evening | 5 PM | Pixels to Punk Rainy Arcade | Pixels to Punk Cyber Icons |
+| Night | 9 PM | Pixels to Punk CRT After Midnight | Pixels to Punk Cyber Icons |
+
+### How People Use It
+
+To turn on automatic switching:
+
+```text
+Pixels to Punk: Enable Time-of-Day Switching
+```
+
+To apply the right theme once:
+
+```text
+Pixels to Punk: Apply Current Time-of-Day Theme
+```
+
+To turn off automatic switching:
+
+```text
+Pixels to Punk: Disable Time-of-Day Switching
+```
+
+### Where To Update It
+
+The switching code lives here:
+
+```text
+src/extension.js
+```
+
+The command list lives in `package.json` under:
+
+```text
+contributes.commands
+```
+
+The user settings live in `package.json` under:
+
+```text
+contributes.configuration
+```
+
+The command activation list lives in `package.json` under:
+
+```text
+activationEvents
+```
+
+### When To Update It
+
+Update time-of-day switching when:
+
+- the default day theme should change
+- the default evening theme should change
+- the default night theme should change
+- a light pairing needs light icons
+- a dark pairing needs dark icons
+- the start times need to feel more natural
+- users need a clearer on or off command
+
+### Theme Fit Notes
+
+The default day theme uses light icons because it is a light theme.
+
+The default evening and night themes use dark icons because they are dark themes.
+
+If a future default uses a high-contrast theme, check the icon theme too. The pair should be readable, not just colorful.
+
 ## Test Terminal Colors
 
 The theme controls terminal colors.
@@ -380,13 +488,13 @@ If that version does not have a GitHub Release yet, the workflow:
 Example:
 
 ```text
-1.0.5
+1.0.6
 ```
 
 That becomes:
 
 ```text
-v1.0.5
+v1.0.6
 ```
 
 If that release already exists, the workflow exits without publishing another one.
@@ -425,7 +533,7 @@ Example:
 
 ```sh
 git add .
-git commit -m "Bump release to v1.0.5"
+git commit -m "Bump release to v1.0.6"
 git push
 ```
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -94,6 +94,60 @@ To undo a mood preset:
 
 That clears the settings the mood preset changed.
 
+## Optional: Switch Themes By Time Of Day
+
+Time-of-day switching changes the theme for the folder you have open.
+
+It is off until you turn it on.
+
+It does not change your code.
+
+The default times are:
+
+- **Day** starts at 7 AM: Soft Focus Day with light icons
+- **Evening** starts at 5 PM: Rainy Arcade with dark icons
+- **Night** starts at 9 PM: CRT After Midnight with dark icons
+
+To turn it on:
+
+1. Open a project folder in VS Code.
+2. Press `Command + Shift + P`.
+3. Type:
+
+   ```text
+   Pixels to Punk: Enable Time-of-Day Switching
+   ```
+
+4. Press Enter.
+
+To change the theme right now without turning on automatic switching:
+
+1. Press `Command + Shift + P`.
+2. Type:
+
+   ```text
+   Pixels to Punk: Apply Current Time-of-Day Theme
+   ```
+
+3. Press Enter.
+
+To turn automatic switching off:
+
+1. Press `Command + Shift + P`.
+2. Type:
+
+   ```text
+   Pixels to Punk: Disable Time-of-Day Switching
+   ```
+
+3. Press Enter.
+
+If you want different times or themes, open VS Code Settings and search for:
+
+```text
+Pixels to Punk Time Of Day
+```
+
 ## If The Theme Does Not Show Up
 
 Sometimes VS Code needs a quick refresh.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You get:
 - high-contrast themes
 - special file icons for common code files
 - workspace mood presets
+- optional time-of-day theme switching
 - terminal colors
 - Git, Problems, Debug Console, and Output panel colors
 
@@ -57,6 +58,8 @@ It can change:
 - file icons
 
 It can also apply optional workspace mood presets. A mood preset is one command that picks a color theme, icon theme, and a few editor settings for the folder you have open.
+
+It can also switch themes by time of day if you turn that on for a workspace.
 
 It does not change your code.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixels-to-punk-cyber",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixels-to-punk-cyber",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "devDependencies": {
         "@vscode/vsce": "^3.9.1"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pixels-to-punk-cyber",
   "displayName": "Pixels to Punk Cyber",
   "description": "Neon punk VS Code themes inspired by the From Pixels to Punk brand, with anime-pop color, punk energy, and coding comfort.",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "publisher": "local",
   "license": "MIT",
   "main": "./src/extension.js",
@@ -22,13 +22,17 @@
     "Other"
   ],
   "activationEvents": [
+    "onStartupFinished",
     "onCommand:pixelsToPunk.pickMoodPreset",
     "onCommand:pixelsToPunk.applyDeepWorkPreset",
     "onCommand:pixelsToPunk.applyTerminalNightPreset",
     "onCommand:pixelsToPunk.applyZineShopPreset",
     "onCommand:pixelsToPunk.applyMaximumNeonPreset",
     "onCommand:pixelsToPunk.applyLowGlarePreset",
-    "onCommand:pixelsToPunk.resetMoodPreset"
+    "onCommand:pixelsToPunk.resetMoodPreset",
+    "onCommand:pixelsToPunk.applyCurrentTimeOfDayTheme",
+    "onCommand:pixelsToPunk.enableTimeOfDaySwitching",
+    "onCommand:pixelsToPunk.disableTimeOfDaySwitching"
   ],
   "contributes": {
     "commands": [
@@ -66,8 +70,94 @@
         "command": "pixelsToPunk.resetMoodPreset",
         "title": "Pixels to Punk: Reset Workspace Mood Preset",
         "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.applyCurrentTimeOfDayTheme",
+        "title": "Pixels to Punk: Apply Current Time-of-Day Theme",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.enableTimeOfDaySwitching",
+        "title": "Pixels to Punk: Enable Time-of-Day Switching",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.disableTimeOfDaySwitching",
+        "title": "Pixels to Punk: Disable Time-of-Day Switching",
+        "category": "Pixels to Punk"
       }
     ],
+    "configuration": {
+      "title": "Pixels to Punk",
+      "properties": {
+        "pixelsToPunk.timeOfDay.enabled": {
+          "type": "boolean",
+          "default": false,
+          "scope": "resource",
+          "description": "Automatically apply the matching Pixels to Punk time-of-day theme for the current workspace."
+        },
+        "pixelsToPunk.timeOfDay.dayStartHour": {
+          "type": "number",
+          "default": 7,
+          "minimum": 0,
+          "maximum": 23,
+          "scope": "resource",
+          "description": "Hour when the day theme starts, using 24-hour time."
+        },
+        "pixelsToPunk.timeOfDay.eveningStartHour": {
+          "type": "number",
+          "default": 17,
+          "minimum": 0,
+          "maximum": 23,
+          "scope": "resource",
+          "description": "Hour when the evening theme starts, using 24-hour time."
+        },
+        "pixelsToPunk.timeOfDay.nightStartHour": {
+          "type": "number",
+          "default": 21,
+          "minimum": 0,
+          "maximum": 23,
+          "scope": "resource",
+          "description": "Hour when the night theme starts, using 24-hour time."
+        },
+        "pixelsToPunk.timeOfDay.dayTheme": {
+          "type": "string",
+          "default": "Pixels to Punk Soft Focus Day",
+          "scope": "resource",
+          "description": "Color theme to use during the day."
+        },
+        "pixelsToPunk.timeOfDay.eveningTheme": {
+          "type": "string",
+          "default": "Pixels to Punk Rainy Arcade",
+          "scope": "resource",
+          "description": "Color theme to use during the evening."
+        },
+        "pixelsToPunk.timeOfDay.nightTheme": {
+          "type": "string",
+          "default": "Pixels to Punk CRT After Midnight",
+          "scope": "resource",
+          "description": "Color theme to use at night."
+        },
+        "pixelsToPunk.timeOfDay.dayIconTheme": {
+          "type": "string",
+          "default": "pixels-to-punk-cyber-icons-light",
+          "scope": "resource",
+          "description": "File icon theme to use during the day."
+        },
+        "pixelsToPunk.timeOfDay.eveningIconTheme": {
+          "type": "string",
+          "default": "pixels-to-punk-cyber-icons",
+          "scope": "resource",
+          "description": "File icon theme to use during the evening."
+        },
+        "pixelsToPunk.timeOfDay.nightIconTheme": {
+          "type": "string",
+          "default": "pixels-to-punk-cyber-icons",
+          "scope": "resource",
+          "description": "File icon theme to use at night."
+        }
+      }
+    },
     "iconThemes": [
       {
         "id": "pixels-to-punk-cyber-icons",

--- a/src/extension.js
+++ b/src/extension.js
@@ -13,6 +13,9 @@ const PRESET_SETTINGS = [
   "terminal.integrated.tabs.enabled"
 ];
 
+const TIME_OF_DAY_NAMESPACE = "pixelsToPunk.timeOfDay";
+const TIME_OF_DAY_CHECK_INTERVAL_MS = 15 * 60 * 1000;
+
 const presets = [
   {
     id: "deepWork",
@@ -106,6 +109,27 @@ const presets = [
   }
 ];
 
+const timeOfDayParts = [
+  {
+    id: "day",
+    label: "Day",
+    themeSetting: "dayTheme",
+    iconThemeSetting: "dayIconTheme"
+  },
+  {
+    id: "evening",
+    label: "Evening",
+    themeSetting: "eveningTheme",
+    iconThemeSetting: "eveningIconTheme"
+  },
+  {
+    id: "night",
+    label: "Night",
+    themeSetting: "nightTheme",
+    iconThemeSetting: "nightIconTheme"
+  }
+];
+
 async function updateSetting(key, value) {
   await vscode.workspace
     .getConfiguration()
@@ -118,8 +142,102 @@ function hasWorkspace() {
 
 function showOpenWorkspaceMessage() {
   vscode.window.showWarningMessage(
-    "Open a folder or workspace first. Pixels to Punk mood presets only change workspace settings."
+    "Open a folder or workspace first. Pixels to Punk commands only change workspace settings."
   );
+}
+
+function getTimeOfDayConfig() {
+  return vscode.workspace.getConfiguration(TIME_OF_DAY_NAMESPACE);
+}
+
+function getHour(config, key) {
+  const value = config.get(key);
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(23, Math.floor(value)));
+}
+
+function getCurrentTimeOfDayPart(date = new Date()) {
+  const config = getTimeOfDayConfig();
+  const hour = date.getHours();
+  const dayStartHour = getHour(config, "dayStartHour");
+  const eveningStartHour = getHour(config, "eveningStartHour");
+  const nightStartHour = getHour(config, "nightStartHour");
+
+  if (hour >= nightStartHour || hour < dayStartHour) {
+    return timeOfDayParts.find((part) => part.id === "night");
+  }
+
+  if (hour >= eveningStartHour) {
+    return timeOfDayParts.find((part) => part.id === "evening");
+  }
+
+  return timeOfDayParts.find((part) => part.id === "day");
+}
+
+function getTimeOfDayTheme(part) {
+  const config = getTimeOfDayConfig();
+
+  return {
+    colorTheme: config.get(part.themeSetting),
+    iconTheme: config.get(part.iconThemeSetting)
+  };
+}
+
+async function applyTimeOfDayTheme(showMessage = true) {
+  if (!hasWorkspace()) {
+    showOpenWorkspaceMessage();
+    return;
+  }
+
+  const part = getCurrentTimeOfDayPart();
+  const { colorTheme, iconTheme } = getTimeOfDayTheme(part);
+
+  await updateSetting("workbench.colorTheme", colorTheme);
+  await updateSetting("workbench.iconTheme", iconTheme);
+
+  if (showMessage) {
+    vscode.window.showInformationMessage(
+      `Pixels to Punk ${part.label} theme applied to workspace settings.`
+    );
+  }
+}
+
+async function enableTimeOfDaySwitching() {
+  if (!hasWorkspace()) {
+    showOpenWorkspaceMessage();
+    return;
+  }
+
+  await updateSetting(`${TIME_OF_DAY_NAMESPACE}.enabled`, true);
+  await applyTimeOfDayTheme(false);
+  vscode.window.showInformationMessage(
+    "Pixels to Punk time-of-day switching enabled for this workspace."
+  );
+}
+
+async function disableTimeOfDaySwitching() {
+  if (!hasWorkspace()) {
+    showOpenWorkspaceMessage();
+    return;
+  }
+
+  await updateSetting(`${TIME_OF_DAY_NAMESPACE}.enabled`, false);
+  vscode.window.showInformationMessage(
+    "Pixels to Punk time-of-day switching disabled for this workspace."
+  );
+}
+
+function isTimeOfDaySwitchingEnabled() {
+  return Boolean(getTimeOfDayConfig().get("enabled"));
+}
+
+function maybeApplyAutomaticTimeOfDayTheme() {
+  if (hasWorkspace() && isTimeOfDaySwitchingEnabled()) {
+    applyTimeOfDayTheme(false);
+  }
 }
 
 async function applyPreset(preset) {
@@ -173,7 +291,24 @@ async function pickMoodPreset() {
 function activate(context) {
   context.subscriptions.push(
     vscode.commands.registerCommand("pixelsToPunk.pickMoodPreset", pickMoodPreset),
-    vscode.commands.registerCommand("pixelsToPunk.resetMoodPreset", resetPreset)
+    vscode.commands.registerCommand("pixelsToPunk.resetMoodPreset", resetPreset),
+    vscode.commands.registerCommand(
+      "pixelsToPunk.applyCurrentTimeOfDayTheme",
+      () => applyTimeOfDayTheme(true)
+    ),
+    vscode.commands.registerCommand(
+      "pixelsToPunk.enableTimeOfDaySwitching",
+      enableTimeOfDaySwitching
+    ),
+    vscode.commands.registerCommand(
+      "pixelsToPunk.disableTimeOfDaySwitching",
+      disableTimeOfDaySwitching
+    ),
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration(TIME_OF_DAY_NAMESPACE)) {
+        maybeApplyAutomaticTimeOfDayTheme();
+      }
+    })
   );
 
   for (const preset of presets) {
@@ -181,6 +316,14 @@ function activate(context) {
       vscode.commands.registerCommand(preset.command, () => applyPreset(preset))
     );
   }
+
+  maybeApplyAutomaticTimeOfDayTheme();
+
+  const timer = setInterval(
+    maybeApplyAutomaticTimeOfDayTheme,
+    TIME_OF_DAY_CHECK_INTERVAL_MS
+  );
+  context.subscriptions.push({ dispose: () => clearInterval(timer) });
 }
 
 function deactivate() {}


### PR DESCRIPTION
## What changed

Adds optional Pixels to Punk time-of-day theme switching for workspaces.

New commands:
- Pixels to Punk: Apply Current Time-of-Day Theme
- Pixels to Punk: Enable Time-of-Day Switching
- Pixels to Punk: Disable Time-of-Day Switching

Default pairings:
- Day, 7 AM: Pixels to Punk Soft Focus Day with Pixels to Punk Cyber Icons Light
- Evening, 5 PM: Pixels to Punk Rainy Arcade with Pixels to Punk Cyber Icons
- Night, 9 PM: Pixels to Punk CRT After Midnight with Pixels to Punk Cyber Icons

The feature is opt-in. Automatic switching only runs when `pixelsToPunk.timeOfDay.enabled` is true for the workspace.

## Settings

Adds workspace settings for:
- enabled state
- day/evening/night start hours
- day/evening/night color themes
- day/evening/night icon themes

## Version

Bumps the extension version to 1.0.6 so merging this PR can publish a fresh release through the main-merge release workflow.

## Documentation

Updates README.md, QUICKSTART.md, and DEV.md with plain-language guidance covering:
- what time-of-day switching is
- how non-devs turn it on or off
- how to apply the current time theme once
- where maintainers update commands and settings
- when the defaults should change
- why light/dark icon pairings matter

## Validation

- npm run build:file-icons
- node --check src/extension.js
- node --check scripts/install-vsix.js
- package/package-lock JSON parse and version consistency check
- npm run package
- git diff --check

Closes #3