### PR TITLE
[codex] Add matching theme pair commands

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -32,7 +32,7 @@ VS Code reads the JSON and SVG files in this repo.
 | `icons/light/` | Holds the light SVG icons. |
 | `icons/pixels-to-punk-cyber-icon-theme.json` | Maps files to dark icons. |
 | `icons/pixels-to-punk-cyber-light-icon-theme.json` | Maps files to light icons. |
-| `src/extension.js` | Adds command palette commands, including workspace mood presets and time-of-day switching. |
+| `src/extension.js` | Adds command palette commands, including theme pairs, workspace mood presets, and time-of-day switching. |
 | `scripts/build-theme-variants.js` | Builds theme variants from palettes. |
 | `scripts/build-file-icons.js` | Builds file icons and icon maps. |
 | `scripts/terminal-colors.js` | Prints terminal colors for testing. |
@@ -288,6 +288,79 @@ Update presets when:
 - a dark preset needs a dark icon theme
 - users need a clearer reset path
 - a new mood gets added
+
+## Matching Theme Pair Commands
+
+A matching theme pair is one command that sets:
+
+- `workbench.colorTheme`
+- `workbench.iconTheme`
+
+It is useful when a person wants the color theme and icon theme to match without picking both by hand.
+
+### Current Pairs
+
+| Pair | Color Theme | Icon Theme |
+| --- | --- | --- |
+| Cyber Dark | Pixels to Punk Cyber Dark | Pixels to Punk Cyber Icons |
+| Cyber Light | Pixels to Punk Cyber Light | Pixels to Punk Cyber Icons Light |
+| Soft Focus Day | Pixels to Punk Soft Focus Day | Pixels to Punk Cyber Icons Light |
+| Soft Focus Night | Pixels to Punk Soft Focus Night | Pixels to Punk Cyber Icons |
+| High Contrast Dark | Pixels to Punk Original High Contrast | Pixels to Punk Cyber Icons |
+| High Contrast Light | Pixels to Punk Electric Sticker Sheet High Contrast | Pixels to Punk Cyber Icons Light |
+
+### How People Use Them
+
+Run:
+
+```text
+Pixels to Punk: Pick Matching Theme Pair
+```
+
+They can also run a pair directly:
+
+- `Pixels to Punk: Activate Cyber Dark Pair`
+- `Pixels to Punk: Activate Cyber Light Pair`
+- `Pixels to Punk: Activate Soft Focus Day Pair`
+- `Pixels to Punk: Activate Soft Focus Night Pair`
+- `Pixels to Punk: Activate High Contrast Dark Pair`
+- `Pixels to Punk: Activate High Contrast Light Pair`
+
+To only fix the icon theme for the current color theme, run:
+
+```text
+Pixels to Punk: Activate Matching Icon Theme
+```
+
+### Where To Update Pairs
+
+The pair list lives in:
+
+```text
+src/extension.js
+```
+
+The command list lives in `package.json` under:
+
+```text
+contributes.commands
+```
+
+The command activation list lives in `package.json` under:
+
+```text
+activationEvents
+```
+
+### When To Update Pairs
+
+Update matching pairs when:
+
+- a theme should have a different icon theme
+- a new common pair is needed
+- a light theme needs light icons
+- a dark theme needs dark icons
+- a high-contrast theme needs a clearer icon pairing
 
 ## Time-Of-Day Theme Switching
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -53,6 +53,37 @@ So if you pick a light color theme, you may want to pick the light icon theme yo
 
 Now your folders and files should have Pixels to Punk icons.
 
+## Optional: Pick A Matching Pair
+
+A matching pair changes the color theme and icon theme together.
+
+That means you do not have to pick them one at a time.
+
+1. Open a project folder in VS Code.
+2. Press `Command + Shift + P`.
+3. Type:
+
+   ```text
+   Pixels to Punk: Pick Matching Theme Pair
+   ```
+
+4. Pick a pair.
+
+You can also run direct commands like:
+
+- `Pixels to Punk: Activate Cyber Dark Pair`
+- `Pixels to Punk: Activate Cyber Light Pair`
+- `Pixels to Punk: Activate Soft Focus Day Pair`
+- `Pixels to Punk: Activate Soft Focus Night Pair`
+- `Pixels to Punk: Activate High Contrast Dark Pair`
+- `Pixels to Punk: Activate High Contrast Light Pair`
+
+If you already picked a color theme and only want the icon theme fixed, run:
+
+```text
+Pixels to Punk: Activate Matching Icon Theme
+```
+
 ## Optional: Pick A Workspace Mood
 
 A mood preset is a shortcut.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You get:
 - special file icons for common code files
 - workspace mood presets
 - optional time-of-day theme switching
+- commands that pair matching colors and icons
 - terminal colors
 - Git, Problems, Debug Console, and Output panel colors
 
@@ -60,6 +61,8 @@ It can change:
 It can also apply optional workspace mood presets. A mood preset is one command that picks a color theme, icon theme, and a few editor settings for the folder you have open.
 
 It can also switch themes by time of day if you turn that on for a workspace.
+
+It can also apply matching color-theme and icon-theme pairs with one command.
 
 It does not change your code.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixels-to-punk-cyber",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixels-to-punk-cyber",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "devDependencies": {
         "@vscode/vsce": "^3.9.1"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pixels-to-punk-cyber",
   "displayName": "Pixels to Punk Cyber",
   "description": "Neon punk VS Code themes inspired by the From Pixels to Punk brand, with anime-pop color, punk energy, and coding comfort.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "publisher": "local",
   "license": "MIT",
   "main": "./src/extension.js",
@@ -32,7 +32,15 @@
     "onCommand:pixelsToPunk.resetMoodPreset",
     "onCommand:pixelsToPunk.applyCurrentTimeOfDayTheme",
     "onCommand:pixelsToPunk.enableTimeOfDaySwitching",
-    "onCommand:pixelsToPunk.disableTimeOfDaySwitching"
+    "onCommand:pixelsToPunk.disableTimeOfDaySwitching",
+    "onCommand:pixelsToPunk.pickThemePair",
+    "onCommand:pixelsToPunk.activateCyberDarkPair",
+    "onCommand:pixelsToPunk.activateCyberLightPair",
+    "onCommand:pixelsToPunk.activateSoftFocusDayPair",
+    "onCommand:pixelsToPunk.activateSoftFocusNightPair",
+    "onCommand:pixelsToPunk.activateHighContrastDarkPair",
+    "onCommand:pixelsToPunk.activateHighContrastLightPair",
+    "onCommand:pixelsToPunk.activateMatchingIconTheme"
   ],
   "contributes": {
     "commands": [
@@ -84,6 +92,46 @@
       {
         "command": "pixelsToPunk.disableTimeOfDaySwitching",
         "title": "Pixels to Punk: Disable Time-of-Day Switching",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.pickThemePair",
+        "title": "Pixels to Punk: Pick Matching Theme Pair",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.activateCyberDarkPair",
+        "title": "Pixels to Punk: Activate Cyber Dark Pair",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.activateCyberLightPair",
+        "title": "Pixels to Punk: Activate Cyber Light Pair",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.activateSoftFocusDayPair",
+        "title": "Pixels to Punk: Activate Soft Focus Day Pair",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.activateSoftFocusNightPair",
+        "title": "Pixels to Punk: Activate Soft Focus Night Pair",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.activateHighContrastDarkPair",
+        "title": "Pixels to Punk: Activate High Contrast Dark Pair",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.activateHighContrastLightPair",
+        "title": "Pixels to Punk: Activate High Contrast Light Pair",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.activateMatchingIconTheme",
+        "title": "Pixels to Punk: Activate Matching Icon Theme",
         "category": "Pixels to Punk"
       }
     ],

--- a/src/extension.js
+++ b/src/extension.js
@@ -130,10 +130,113 @@ const timeOfDayParts = [
   }
 ];
 
+const themePairs = [
+  {
+    id: "cyberDark",
+    label: "Cyber Dark",
+    description: "Classic dark cyber colors with dark icons.",
+    command: "pixelsToPunk.activateCyberDarkPair",
+    colorTheme: "Pixels to Punk Cyber Dark",
+    iconTheme: "pixels-to-punk-cyber-icons"
+  },
+  {
+    id: "cyberLight",
+    label: "Cyber Light",
+    description: "Classic light cyber colors with light icons.",
+    command: "pixelsToPunk.activateCyberLightPair",
+    colorTheme: "Pixels to Punk Cyber Light",
+    iconTheme: "pixels-to-punk-cyber-icons-light"
+  },
+  {
+    id: "softFocusDay",
+    label: "Soft Focus Day",
+    description: "Lower-glare light colors with light icons.",
+    command: "pixelsToPunk.activateSoftFocusDayPair",
+    colorTheme: "Pixels to Punk Soft Focus Day",
+    iconTheme: "pixels-to-punk-cyber-icons-light"
+  },
+  {
+    id: "softFocusNight",
+    label: "Soft Focus Night",
+    description: "Lower-glare dark colors with dark icons.",
+    command: "pixelsToPunk.activateSoftFocusNightPair",
+    colorTheme: "Pixels to Punk Soft Focus Night",
+    iconTheme: "pixels-to-punk-cyber-icons"
+  },
+  {
+    id: "highContrastDark",
+    label: "High Contrast Dark",
+    description: "Strong dark readability with dark icons.",
+    command: "pixelsToPunk.activateHighContrastDarkPair",
+    colorTheme: "Pixels to Punk Original High Contrast",
+    iconTheme: "pixels-to-punk-cyber-icons"
+  },
+  {
+    id: "highContrastLight",
+    label: "High Contrast Light",
+    description: "Strong light readability with light icons.",
+    command: "pixelsToPunk.activateHighContrastLightPair",
+    colorTheme: "Pixels to Punk Electric Sticker Sheet High Contrast",
+    iconTheme: "pixels-to-punk-cyber-icons-light"
+  }
+];
+
 async function updateSetting(key, value) {
   await vscode.workspace
     .getConfiguration()
     .update(key, value, vscode.ConfigurationTarget.Workspace);
+}
+
+async function applyThemePair(pair) {
+  if (!hasWorkspace()) {
+    showOpenWorkspaceMessage();
+    return;
+  }
+
+  await updateSetting("workbench.colorTheme", pair.colorTheme);
+  await updateSetting("workbench.iconTheme", pair.iconTheme);
+
+  vscode.window.showInformationMessage(
+    `Pixels to Punk ${pair.label} pair applied to workspace settings.`
+  );
+}
+
+async function pickThemePair() {
+  const selection = await vscode.window.showQuickPick(
+    themePairs.map((pair) => ({
+      label: pair.label,
+      description: pair.description,
+      pair
+    })),
+    {
+      title: "Pick a Pixels to Punk matching theme pair",
+      placeHolder: "Choose a color theme and matching icon theme"
+    }
+  );
+
+  if (selection) {
+    await applyThemePair(selection.pair);
+  }
+}
+
+async function activateMatchingIconTheme() {
+  if (!hasWorkspace()) {
+    showOpenWorkspaceMessage();
+    return;
+  }
+
+  const currentTheme = vscode.workspace
+    .getConfiguration("workbench")
+    .get("colorTheme", "");
+  const lightThemeWords = ["Light", "Day", "Candy", "Photocopy", "Mall", "Electric", "Zine"];
+  const iconTheme = lightThemeWords.some((word) => currentTheme.includes(word))
+    ? "pixels-to-punk-cyber-icons-light"
+    : "pixels-to-punk-cyber-icons";
+
+  await updateSetting("workbench.iconTheme", iconTheme);
+  vscode.window.showInformationMessage(
+    "Pixels to Punk matching icon theme applied to workspace settings."
+  );
 }
 
 function hasWorkspace() {
@@ -304,6 +407,11 @@ function activate(context) {
       "pixelsToPunk.disableTimeOfDaySwitching",
       disableTimeOfDaySwitching
     ),
+    vscode.commands.registerCommand("pixelsToPunk.pickThemePair", pickThemePair),
+    vscode.commands.registerCommand(
+      "pixelsToPunk.activateMatchingIconTheme",
+      activateMatchingIconTheme
+    ),
     vscode.workspace.onDidChangeConfiguration((event) => {
       if (event.affectsConfiguration(TIME_OF_DAY_NAMESPACE)) {
         maybeApplyAutomaticTimeOfDayTheme();
@@ -314,6 +422,12 @@ function activate(context) {
   for (const preset of presets) {
     context.subscriptions.push(
       vscode.commands.registerCommand(preset.command, () => applyPreset(preset))
+    );
+  }
+
+  for (const pair of themePairs) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(pair.command, () => applyThemePair(pair))
     );
   }
 


### PR DESCRIPTION
## What changed

Adds commands that apply matching Pixels to Punk color theme and icon theme pairs in one step.

New commands:
- Pixels to Punk: Pick Matching Theme Pair
- Pixels to Punk: Activate Cyber Dark Pair
- Pixels to Punk: Activate Cyber Light Pair
- Pixels to Punk: Activate Soft Focus Day Pair
- Pixels to Punk: Activate Soft Focus Night Pair
- Pixels to Punk: Activate High Contrast Dark Pair
- Pixels to Punk: Activate High Contrast Light Pair
- Pixels to Punk: Activate Matching Icon Theme

## Version

Bumps the extension version to 1.0.7 for the automatic main-merge release flow.

## Validation

- npm run build:file-icons
- node --check src/extension.js
- node --check scripts/install-vsix.js
- package/package-lock version check
- git diff --check
- npm run package

Closes #4