### PR TITLE
[codex] Add distinct status bar states

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Build generated file icons
         run: npm run build:file-icons
 
+      - name: Build generated status bar states
+        run: npm run build:status-bar-states
+
       - name: Package VS Code extension
         run: npm run package
 

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -73,6 +73,10 @@ jobs:
         if: steps.existing_release.outputs.exists == 'false'
         run: npm run build:file-icons
 
+      - name: Build generated status bar states
+        if: steps.existing_release.outputs.exists == 'false'
+        run: npm run build:status-bar-states
+
       - name: Package VS Code extension
         if: steps.existing_release.outputs.exists == 'false'
         run: npm run package

--- a/DEV.md
+++ b/DEV.md
@@ -36,6 +36,7 @@ VS Code reads the JSON and SVG files in this repo.
 | `src/extension.js` | Adds command palette commands, including theme pairs, workspace mood presets, and time-of-day switching. |
 | `scripts/build-theme-variants.js` | Builds theme variants from palettes. |
 | `scripts/build-file-icons.js` | Builds file icons and icon maps. |
+| `scripts/build-status-bar-states.js` | Builds status bar warning, error, remote, debug, and hover colors. |
 | `scripts/terminal-colors.js` | Prints terminal colors for testing. |
 | `README.md` | Home page for the repo. |
 | `QUICKSTART.md` | Short install guide for users. |
@@ -540,6 +541,76 @@ The default day theme uses light icons because it is a light theme.
 The default evening and night themes use dark icons because they are dark themes.
 
 If a future default uses a high-contrast theme, check the icon theme too. The pair should be readable, not just colorful.
+
+## Status Bar States
+
+The status bar is the strip at the bottom of VS Code.
+
+It can show different states:
+
+- normal
+- no folder open
+- debugging
+- remote window
+- warning
+- error
+- hover
+- active item
+
+This project gives those states clear colors in every theme.
+
+### What It Changes
+
+The status bar builder updates:
+
+- `statusBar.background`
+- `statusBar.foreground`
+- `statusBar.noFolderBackground`
+- `statusBar.noFolderForeground`
+- `statusBar.debuggingBackground`
+- `statusBar.debuggingForeground`
+- `statusBarItem.activeBackground`
+- `statusBarItem.activeForeground`
+- `statusBarItem.hoverBackground`
+- `statusBarItem.remoteBackground`
+- `statusBarItem.remoteForeground`
+- `statusBarItem.errorBackground`
+- `statusBarItem.errorForeground`
+- `statusBarItem.warningBackground`
+- `statusBarItem.warningForeground`
+
+### Where To Update It
+
+The builder lives here:
+
+```text
+scripts/build-status-bar-states.js
+```
+
+Run it with:
+
+```sh
+npm run build:status-bar-states
+```
+
+The release workflows run it before packaging.
+
+### When To Update It
+
+Update status bar states when:
+
+- debug mode is not obvious enough
+- warning or error items are hard to read
+- remote status blends into the normal status bar
+- a light theme needs darker status bar text
+- a dark theme needs brighter status bar text
+- hover or active items are too subtle
+
+### Theme Fit Notes
+
+The builder picks colors from each theme's own palette.
+
+That keeps neon themes loud, soft themes calmer, and high-contrast themes readable.
 
 ## Test Terminal Colors
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You get:
 - workspace mood presets
 - optional time-of-day theme switching
 - commands that pair matching colors and icons
+- clearer status bar states
 - terminal colors
 - Git, Problems, Debug Console, and Output panel colors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pixels-to-punk-cyber",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixels-to-punk-cyber",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "devDependencies": {
         "@vscode/vsce": "^3.9.1"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pixels-to-punk-cyber",
   "displayName": "Pixels to Punk Cyber",
   "description": "Neon punk VS Code themes inspired by the From Pixels to Punk brand, with anime-pop color, punk energy, and coding comfort.",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "publisher": "local",
   "license": "MIT",
   "main": "./src/extension.js",
@@ -385,6 +385,7 @@
   "scripts": {
     "clean": "rm -rf node_modules pixels-to-punk-cyber-*.vsix",
     "build:file-icons": "node scripts/build-file-icons.js",
+    "build:status-bar-states": "node scripts/build-status-bar-states.js",
     "demo:terminal-colors": "node scripts/terminal-colors.js",
     "package": "npx --no-install vsce package --allow-missing-repository",
     "install:vsix": "node scripts/install-vsix.js"

--- a/scripts/build-status-bar-states.js
+++ b/scripts/build-status-bar-states.js
@@ -1,0 +1,93 @@
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const themesDir = path.join(root, "themes");
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJson(file, value) {
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function hexToRgb(hex) {
+  const value = hex.replace("#", "").slice(0, 6);
+  const int = parseInt(value, 16);
+  return {
+    r: (int >> 16) & 255,
+    g: (int >> 8) & 255,
+    b: int & 255
+  };
+}
+
+function relativeLuminance(hex) {
+  const { r, g, b } = hexToRgb(hex);
+  const values = [r, g, b].map((channel) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+
+  return values[0] * 0.2126 + values[1] * 0.7152 + values[2] * 0.0722;
+}
+
+function readableText(background) {
+  return relativeLuminance(background) > 0.45 ? "#101019" : "#FFFFFF";
+}
+
+function pick(colors, ...keys) {
+  for (const key of keys) {
+    const value = colors[key];
+    if (typeof value === "string" && value.startsWith("#") && value.length >= 7) {
+      return value;
+    }
+  }
+
+  return "#24D9FF";
+}
+
+function applyStatusBarStates(theme) {
+  const colors = theme.colors || {};
+  const normalBackground = pick(colors, "statusBar.background", "activityBar.background");
+  const normalForeground = pick(colors, "statusBar.foreground", "foreground");
+  const panelBackground = pick(colors, "panel.background", "sideBar.background");
+  const accent = pick(colors, "activityBarBadge.background", "focusBorder", "terminal.ansiCyan");
+  const debug = pick(colors, "terminal.ansiYellow", "editorWarning.foreground", "statusBar.debuggingBackground");
+  const warning = pick(colors, "editorWarning.foreground", "terminal.ansiYellow");
+  const error = pick(colors, "editorError.foreground", "terminal.ansiRed");
+  const remote = pick(colors, "terminal.ansiBlue", "terminal.ansiCyan", "focusBorder");
+  const hover = pick(colors, "list.hoverBackground", "editor.selectionBackground", "button.hoverBackground");
+
+  theme.colors = {
+    ...colors,
+    "statusBar.background": normalBackground,
+    "statusBar.foreground": normalForeground,
+    "statusBar.noFolderBackground": panelBackground,
+    "statusBar.noFolderForeground": normalForeground,
+    "statusBar.debuggingBackground": debug,
+    "statusBar.debuggingForeground": readableText(debug),
+    "statusBarItem.activeBackground": accent,
+    "statusBarItem.activeForeground": readableText(accent),
+    "statusBarItem.hoverBackground": hover,
+    "statusBarItem.remoteBackground": remote,
+    "statusBarItem.remoteForeground": readableText(remote),
+    "statusBarItem.errorBackground": error,
+    "statusBarItem.errorForeground": readableText(error),
+    "statusBarItem.warningBackground": warning,
+    "statusBarItem.warningForeground": readableText(warning)
+  };
+}
+
+for (const fileName of fs.readdirSync(themesDir)) {
+  if (!fileName.endsWith("-color-theme.json")) {
+    continue;
+  }
+
+  const file = path.join(themesDir, fileName);
+  const theme = readJson(file);
+  applyStatusBarStates(theme);
+  writeJson(file, theme);
+}

--- a/themes/pixels-to-punk-afterparty-aquarium-color-theme.json
+++ b/themes/pixels-to-punk-afterparty-aquarium-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#123139",
     "sideBarSectionHeader.foreground": "#F6FEFF",
     "statusBar.background": "#0C252B",
-    "statusBar.debuggingBackground": "#0E8A9B",
-    "statusBar.debuggingForeground": "#F6FEFF",
+    "statusBar.debuggingBackground": "#FFD06E",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#F6FEFF",
     "statusBar.noFolderBackground": "#0C252B",
     "tab.activeBackground": "#06191D",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#0C252B",
     "titleBar.activeForeground": "#F6FEFF",
     "titleBar.inactiveBackground": "#06191D",
-    "titleBar.inactiveForeground": "#709AA1"
+    "titleBar.inactiveForeground": "#709AA1",
+    "statusBar.noFolderForeground": "#F6FEFF",
+    "statusBarItem.activeBackground": "#FF7A8A",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#15363E",
+    "statusBarItem.remoteBackground": "#8FB5FF",
+    "statusBarItem.remoteForeground": "#101019",
+    "statusBarItem.errorBackground": "#FF6576",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFD06E",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-arcade-raincoat-color-theme.json
+++ b/themes/pixels-to-punk-arcade-raincoat-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#1A2C43",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#132236",
-    "statusBar.debuggingBackground": "#2F75C7",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#F8D85A",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#132236",
     "tab.activeBackground": "#0B1522",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#132236",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#0B1522",
-    "titleBar.inactiveForeground": "#8297AD"
+    "titleBar.inactiveForeground": "#8297AD",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF4FB3",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#1E2F48",
+    "statusBarItem.remoteBackground": "#65A2FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF5870",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#F8D85A",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-basement-flyer-color-theme.json
+++ b/themes/pixels-to-punk-basement-flyer-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#292421",
     "sideBarSectionHeader.foreground": "#FFF7E8",
     "statusBar.background": "#201C1B",
-    "statusBar.debuggingBackground": "#B83D4A",
-    "statusBar.debuggingForeground": "#FFF7E8",
+    "statusBar.debuggingBackground": "#E0B44D",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFF7E8",
     "statusBar.noFolderBackground": "#201C1B",
     "tab.activeBackground": "#171515",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#201C1B",
     "titleBar.activeForeground": "#FFF7E8",
     "titleBar.inactiveBackground": "#171515",
-    "titleBar.inactiveForeground": "#8F8174"
+    "titleBar.inactiveForeground": "#8F8174",
+    "statusBar.noFolderForeground": "#FFF7E8",
+    "statusBarItem.activeBackground": "#F04E5F",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#2E2724",
+    "statusBarItem.remoteBackground": "#6FA8D8",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF5D63",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#E0B44D",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-blacklight-slushie-color-theme.json
+++ b/themes/pixels-to-punk-blacklight-slushie-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#1D244B",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#151A3A",
-    "statusBar.debuggingBackground": "#7B47E8",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FFE45C",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#151A3A",
     "tab.activeBackground": "#0D1026",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#151A3A",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#0D1026",
-    "titleBar.inactiveForeground": "#8994C0"
+    "titleBar.inactiveForeground": "#8994C0",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF4FD8",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#232A55",
+    "statusBarItem.remoteBackground": "#6EA8FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF5C7A",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFE45C",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-bubblegum-bruise-color-theme.json
+++ b/themes/pixels-to-punk-bubblegum-bruise-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#2A1C45",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#201637",
-    "statusBar.debuggingBackground": "#B94BC2",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FFD166",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#201637",
     "tab.activeBackground": "#160F24",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#201637",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#160F24",
-    "titleBar.inactiveForeground": "#9F88B4"
+    "titleBar.inactiveForeground": "#9F88B4",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF73D8",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#2F204B",
+    "statusBarItem.remoteBackground": "#78A8FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF5F7D",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFD166",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-candy-static-color-theme.json
+++ b/themes/pixels-to-punk-candy-static-color-theme.json
@@ -105,7 +105,7 @@
     "sideBarSectionHeader.background": "#FFFFFF",
     "sideBarSectionHeader.foreground": "#111226",
     "statusBar.background": "#F2F7FF",
-    "statusBar.debuggingBackground": "#D4008F",
+    "statusBar.debuggingBackground": "#B66A00",
     "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#111226",
     "statusBar.noFolderBackground": "#F2F7FF",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#F2F7FF",
     "titleBar.activeForeground": "#111226",
     "titleBar.inactiveBackground": "#FFF8FF",
-    "titleBar.inactiveForeground": "#70758C"
+    "titleBar.inactiveForeground": "#70758C",
+    "statusBar.noFolderForeground": "#111226",
+    "statusBarItem.activeBackground": "#D4008F",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#F2F5FF",
+    "statusBarItem.remoteBackground": "#2D65D8",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#D91E4B",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#B66A00",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-cherry-crt-color-theme.json
+++ b/themes/pixels-to-punk-cherry-crt-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#211820",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#1B141C",
-    "statusBar.debuggingBackground": "#C92A4E",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FFCC4D",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#1B141C",
     "tab.activeBackground": "#120D12",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#1B141C",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#120D12",
-    "titleBar.inactiveForeground": "#9B8791"
+    "titleBar.inactiveForeground": "#9B8791",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF365E",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#291F27",
+    "statusBarItem.remoteBackground": "#69B7FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF365E",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFCC4D",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-crt-after-midnight-color-theme.json
+++ b/themes/pixels-to-punk-crt-after-midnight-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#10262B",
     "sideBarSectionHeader.foreground": "#F2FFFB",
     "statusBar.background": "#0A1B20",
-    "statusBar.debuggingBackground": "#167C74",
-    "statusBar.debuggingForeground": "#F2FFFB",
+    "statusBar.debuggingBackground": "#FFB84D",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#F2FFFB",
     "statusBar.noFolderBackground": "#0A1B20",
     "tab.activeBackground": "#061316",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#0A1B20",
     "titleBar.activeForeground": "#F2FFFB",
     "titleBar.inactiveBackground": "#061316",
-    "titleBar.inactiveForeground": "#6C918B"
+    "titleBar.inactiveForeground": "#6C918B",
+    "statusBar.noFolderForeground": "#F2FFFB",
+    "statusBarItem.activeBackground": "#F05BC3",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#122C32",
+    "statusBarItem.remoteBackground": "#55A6FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF5368",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFB84D",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-cyber-dark-color-theme.json
+++ b/themes/pixels-to-punk-cyber-dark-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#19182A",
     "sideBarSectionHeader.foreground": "#EAF0FF",
     "statusBar.background": "#151421",
-    "statusBar.debuggingBackground": "#C832B8",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FFD166",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#EAF0FF",
     "statusBar.noFolderBackground": "#151421",
     "tab.activeBackground": "#101019",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#151421",
     "titleBar.activeForeground": "#EAF0FF",
     "titleBar.inactiveBackground": "#101019",
-    "titleBar.inactiveForeground": "#8587A6"
+    "titleBar.inactiveForeground": "#8587A6",
+    "statusBar.noFolderForeground": "#EAF0FF",
+    "statusBarItem.activeBackground": "#FF4FD8",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#1F1E35",
+    "statusBarItem.remoteBackground": "#6EA8FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF5C7A",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFD166",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-cyber-dark-for-those-with-glasses-color-theme.json
+++ b/themes/pixels-to-punk-cyber-dark-for-those-with-glasses-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#232638",
     "sideBarSectionHeader.foreground": "#F5F7FB",
     "statusBar.background": "#1E2130",
-    "statusBar.debuggingBackground": "#A95791",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#D7B86B",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#F5F7FB",
     "statusBar.noFolderBackground": "#1E2130",
     "tab.activeBackground": "#161823",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#1E2130",
     "titleBar.activeForeground": "#F5F7FB",
     "titleBar.inactiveBackground": "#161823",
-    "titleBar.inactiveForeground": "#8D94AA"
+    "titleBar.inactiveForeground": "#8D94AA",
+    "statusBar.noFolderForeground": "#F5F7FB",
+    "statusBarItem.activeBackground": "#D879B8",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#282D43",
+    "statusBarItem.remoteBackground": "#88AEE8",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#F07A8D",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#D7B86B",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-cyber-light-color-theme.json
+++ b/themes/pixels-to-punk-cyber-light-color-theme.json
@@ -105,10 +105,10 @@
     "sideBarSectionHeader.background": "#DFF1F4",
     "sideBarSectionHeader.foreground": "#16182A",
     "statusBar.background": "#DFF1F4",
-    "statusBar.debuggingBackground": "#B00070",
+    "statusBar.debuggingBackground": "#A65A00",
     "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#16182A",
-    "statusBar.noFolderBackground": "#DFF1F4",
+    "statusBar.noFolderBackground": "#EAF7F8",
     "tab.activeBackground": "#FFFDF7",
     "tab.activeBorderTop": "#B00070",
     "tab.activeForeground": "#121528",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#EAF7F8",
     "titleBar.activeForeground": "#16182A",
     "titleBar.inactiveBackground": "#FFFDF7",
-    "titleBar.inactiveForeground": "#62677B"
+    "titleBar.inactiveForeground": "#62677B",
+    "statusBar.noFolderForeground": "#16182A",
+    "statusBarItem.activeBackground": "#B00070",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#EDF8F9",
+    "statusBarItem.remoteBackground": "#315FD6",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#D0184F",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#A65A00",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-cyber-light-for-those-with-glasses-color-theme.json
+++ b/themes/pixels-to-punk-cyber-light-for-those-with-glasses-color-theme.json
@@ -105,7 +105,7 @@
     "sideBarSectionHeader.background": "#FCFAF4",
     "sideBarSectionHeader.foreground": "#151926",
     "statusBar.background": "#E7EDF0",
-    "statusBar.debuggingBackground": "#8E3A76",
+    "statusBar.debuggingBackground": "#8B6400",
     "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#151926",
     "statusBar.noFolderBackground": "#E7EDF0",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#E7EDF0",
     "titleBar.activeForeground": "#151926",
     "titleBar.inactiveBackground": "#F7F3EA",
-    "titleBar.inactiveForeground": "#687184"
+    "titleBar.inactiveForeground": "#687184",
+    "statusBar.noFolderForeground": "#151926",
+    "statusBarItem.activeBackground": "#9B2E72",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#EEF2F1",
+    "statusBarItem.remoteBackground": "#335F9F",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#B7334F",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#8B6400",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-electric-sticker-sheet-color-theme.json
+++ b/themes/pixels-to-punk-electric-sticker-sheet-color-theme.json
@@ -105,7 +105,7 @@
     "sideBarSectionHeader.background": "#FFFFFF",
     "sideBarSectionHeader.foreground": "#100817",
     "statusBar.background": "#E9DEFF",
-    "statusBar.debuggingBackground": "#B516DA",
+    "statusBar.debuggingBackground": "#A66F00",
     "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#100817",
     "statusBar.noFolderBackground": "#E9DEFF",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#E9DEFF",
     "titleBar.activeForeground": "#100817",
     "titleBar.inactiveBackground": "#F7F2FF",
-    "titleBar.inactiveForeground": "#766382"
+    "titleBar.inactiveForeground": "#766382",
+    "statusBar.noFolderForeground": "#100817",
+    "statusBarItem.activeBackground": "#D61DFF",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#F1E9FF",
+    "statusBarItem.remoteBackground": "#006FD6",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#D91E4B",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#A66F00",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-electric-sticker-sheet-high-contrast-color-theme.json
+++ b/themes/pixels-to-punk-electric-sticker-sheet-high-contrast-color-theme.json
@@ -105,7 +105,7 @@
     "sideBarSectionHeader.background": "#FFFFFF",
     "sideBarSectionHeader.foreground": "#000000",
     "statusBar.background": "#E7D8FF",
-    "statusBar.debuggingBackground": "#9800C7",
+    "statusBar.debuggingBackground": "#8A5700",
     "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#000000",
     "statusBar.noFolderBackground": "#E7D8FF",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#E7D8FF",
     "titleBar.activeForeground": "#000000",
     "titleBar.inactiveBackground": "#FFFFFF",
-    "titleBar.inactiveForeground": "#5B4B68"
+    "titleBar.inactiveForeground": "#5B4B68",
+    "statusBar.noFolderForeground": "#000000",
+    "statusBarItem.activeBackground": "#B800E6",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#F0E7FF",
+    "statusBarItem.remoteBackground": "#004FB8",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#C9003A",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#8A5700",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-laser-lemonade-color-theme.json
+++ b/themes/pixels-to-punk-laser-lemonade-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#202433",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#171A26",
-    "statusBar.debuggingBackground": "#CC2FA0",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#F8FF4D",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#171A26",
     "tab.activeBackground": "#10121A",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#171A26",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#10121A",
-    "titleBar.inactiveForeground": "#878FA8"
+    "titleBar.inactiveForeground": "#878FA8",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF3DBE",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#222737",
+    "statusBarItem.remoteBackground": "#6EA8FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF526D",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#F8FF4D",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-mall-goth-daydream-color-theme.json
+++ b/themes/pixels-to-punk-mall-goth-daydream-color-theme.json
@@ -105,7 +105,7 @@
     "sideBarSectionHeader.background": "#FFFFFF",
     "sideBarSectionHeader.foreground": "#110B16",
     "statusBar.background": "#E9E2EF",
-    "statusBar.debuggingBackground": "#422653",
+    "statusBar.debuggingBackground": "#9A6429",
     "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#110B16",
     "statusBar.noFolderBackground": "#E9E2EF",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#E9E2EF",
     "titleBar.activeForeground": "#110B16",
     "titleBar.inactiveBackground": "#F7F3FA",
-    "titleBar.inactiveForeground": "#746B7D"
+    "titleBar.inactiveForeground": "#746B7D",
+    "statusBar.noFolderForeground": "#110B16",
+    "statusBarItem.activeBackground": "#9D2F73",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#F1EAF6",
+    "statusBarItem.remoteBackground": "#2D658F",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#C93455",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#9A6429",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-neon-backstage-color-theme.json
+++ b/themes/pixels-to-punk-neon-backstage-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#181733",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#111022",
-    "statusBar.debuggingBackground": "#D42BB2",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FFE05C",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#111022",
     "tab.activeBackground": "#0B0B18",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#111022",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#0B0B18",
-    "titleBar.inactiveForeground": "#777B9D"
+    "titleBar.inactiveForeground": "#777B9D",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF36B7",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#1F1D3B",
+    "statusBarItem.remoteBackground": "#5EA8FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF4C6A",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFE05C",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-original-color-theme.json
+++ b/themes/pixels-to-punk-original-color-theme.json
@@ -105,7 +105,7 @@
     "sideBarSectionHeader.background": "#232858",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#10172A",
-    "statusBar.debuggingBackground": "#D83668",
+    "statusBar.debuggingBackground": "#FF7A5F",
     "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#10172A",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#10172A",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#131B2D",
-    "titleBar.inactiveForeground": "#8B86A4"
+    "titleBar.inactiveForeground": "#8B86A4",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#E051A2",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#252D56",
+    "statusBarItem.remoteBackground": "#295697",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#D83668",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FF7A5F",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-original-high-contrast-color-theme.json
+++ b/themes/pixels-to-punk-original-high-contrast-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#141E3C",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#0A1328",
-    "statusBar.debuggingBackground": "#F02F7A",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FF9A5F",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#0A1328",
     "tab.activeBackground": "#071022",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#0A1328",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#071022",
-    "titleBar.inactiveForeground": "#B2B0C8"
+    "titleBar.inactiveForeground": "#B2B0C8",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF3FA8",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#1B2A5C",
+    "statusBarItem.remoteBackground": "#63A8FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF4D70",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FF9A5F",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-photocopy-riot-color-theme.json
+++ b/themes/pixels-to-punk-photocopy-riot-color-theme.json
@@ -105,7 +105,7 @@
     "sideBarSectionHeader.background": "#FFFFFF",
     "sideBarSectionHeader.foreground": "#050608",
     "statusBar.background": "#E8E7DE",
-    "statusBar.debuggingBackground": "#17191D",
+    "statusBar.debuggingBackground": "#9A5A00",
     "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#050608",
     "statusBar.noFolderBackground": "#E8E7DE",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#E8E7DE",
     "titleBar.activeForeground": "#050608",
     "titleBar.inactiveBackground": "#FAFAF2",
-    "titleBar.inactiveForeground": "#73706A"
+    "titleBar.inactiveForeground": "#73706A",
+    "statusBar.noFolderForeground": "#050608",
+    "statusBarItem.activeBackground": "#D62246",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#F0EFE7",
+    "statusBarItem.remoteBackground": "#005F9E",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#C9183A",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#9A5A00",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-punk-pool-party-color-theme.json
+++ b/themes/pixels-to-punk-punk-pool-party-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#163642",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#102A34",
-    "statusBar.debuggingBackground": "#008E99",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FFE66D",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#102A34",
     "tab.activeBackground": "#081B24",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#102A34",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#081B24",
-    "titleBar.inactiveForeground": "#80A7A7"
+    "titleBar.inactiveForeground": "#80A7A7",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF5A8A",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#163944",
+    "statusBarItem.remoteBackground": "#6ED6FF",
+    "statusBarItem.remoteForeground": "#101019",
+    "statusBarItem.errorBackground": "#FF5D70",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFE66D",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-rainy-arcade-color-theme.json
+++ b/themes/pixels-to-punk-rainy-arcade-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#162436",
     "sideBarSectionHeader.foreground": "#F7FBFF",
     "statusBar.background": "#101B29",
-    "statusBar.debuggingBackground": "#2B75C8",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FFC857",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#F7FBFF",
     "statusBar.noFolderBackground": "#101B29",
     "tab.activeBackground": "#09121D",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#101B29",
     "titleBar.activeForeground": "#F7FBFF",
     "titleBar.inactiveBackground": "#09121D",
-    "titleBar.inactiveForeground": "#71829A"
+    "titleBar.inactiveForeground": "#71829A",
+    "statusBar.noFolderForeground": "#F7FBFF",
+    "statusBarItem.activeBackground": "#FF6BB5",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#19283C",
+    "statusBarItem.remoteBackground": "#6EA8FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF5870",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFC857",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-riot-glow-dark-color-theme.json
+++ b/themes/pixels-to-punk-riot-glow-dark-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#311766",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#170A35",
-    "statusBar.debuggingBackground": "#FF2FA8",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FFE14D",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#170A35",
     "tab.activeBackground": "#24104A",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#170A35",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#24104A",
-    "titleBar.inactiveForeground": "#A58BCF"
+    "titleBar.inactiveForeground": "#A58BCF",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF35B8",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#3A1B72",
+    "statusBarItem.remoteBackground": "#66A8FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF4E5F",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFE14D",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-riot-glow-light-color-theme.json
+++ b/themes/pixels-to-punk-riot-glow-light-color-theme.json
@@ -105,7 +105,7 @@
     "sideBarSectionHeader.background": "#FFFFFF",
     "sideBarSectionHeader.foreground": "#0F0618",
     "statusBar.background": "#EFDAFF",
-    "statusBar.debuggingBackground": "#E0008E",
+    "statusBar.debuggingBackground": "#9F6500",
     "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#0F0618",
     "statusBar.noFolderBackground": "#EFDAFF",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#EFDAFF",
     "titleBar.activeForeground": "#0F0618",
     "titleBar.inactiveBackground": "#FFF4FF",
-    "titleBar.inactiveForeground": "#735F86"
+    "titleBar.inactiveForeground": "#735F86",
+    "statusBar.noFolderForeground": "#0F0618",
+    "statusBarItem.activeBackground": "#E0008E",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#F6E6FF",
+    "statusBarItem.remoteBackground": "#005DD6",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#D82045",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#9F6500",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-soft-focus-day-color-theme.json
+++ b/themes/pixels-to-punk-soft-focus-day-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#FBF8F0",
     "sideBarSectionHeader.foreground": "#111819",
     "statusBar.background": "#E8E6DF",
-    "statusBar.debuggingBackground": "#6D5A7D",
-    "statusBar.debuggingForeground": "#FBF8F0",
+    "statusBar.debuggingBackground": "#875D24",
+    "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#111819",
     "statusBar.noFolderBackground": "#E8E6DF",
     "tab.activeBackground": "#F6F2E8",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#E8E6DF",
     "titleBar.activeForeground": "#111819",
     "titleBar.inactiveBackground": "#F6F2E8",
-    "titleBar.inactiveForeground": "#6E7777"
+    "titleBar.inactiveForeground": "#6E7777",
+    "statusBar.noFolderForeground": "#111819",
+    "statusBarItem.activeBackground": "#8B3D62",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#EEEADF",
+    "statusBarItem.remoteBackground": "#405F8D",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#A63A4A",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#875D24",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-soft-focus-night-color-theme.json
+++ b/themes/pixels-to-punk-soft-focus-night-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#282C30",
     "sideBarSectionHeader.foreground": "#F1EDE2",
     "statusBar.background": "#22262A",
-    "statusBar.debuggingBackground": "#74657F",
-    "statusBar.debuggingForeground": "#F1EDE2",
+    "statusBar.debuggingBackground": "#D5B170",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#F1EDE2",
     "statusBar.noFolderBackground": "#22262A",
     "tab.activeBackground": "#1B1D20",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#22262A",
     "titleBar.activeForeground": "#F1EDE2",
     "titleBar.inactiveBackground": "#1B1D20",
-    "titleBar.inactiveForeground": "#8F938D"
+    "titleBar.inactiveForeground": "#8F938D",
+    "statusBar.noFolderForeground": "#F1EDE2",
+    "statusBarItem.activeBackground": "#D79BB1",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#2E3237",
+    "statusBarItem.remoteBackground": "#9EB8D6",
+    "statusBarItem.remoteForeground": "#101019",
+    "statusBarItem.errorBackground": "#E58B96",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#D5B170",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-sticker-bomb-sunset-color-theme.json
+++ b/themes/pixels-to-punk-sticker-bomb-sunset-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#2B1B36",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#201429",
-    "statusBar.debuggingBackground": "#D93D8F",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FFB84D",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#201429",
     "tab.activeBackground": "#18111F",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#201429",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#18111F",
-    "titleBar.inactiveForeground": "#9E87A4"
+    "titleBar.inactiveForeground": "#9E87A4",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF4FA3",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#301F3A",
+    "statusBarItem.remoteBackground": "#67B7FF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#FF5C70",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFB84D",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-streetlight-noir-color-theme.json
+++ b/themes/pixels-to-punk-streetlight-noir-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#1C242B",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#141A20",
-    "statusBar.debuggingBackground": "#9B5366",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#E0AF57",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#141A20",
     "tab.activeBackground": "#0D1014",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#141A20",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#0D1014",
-    "titleBar.inactiveForeground": "#7C8888"
+    "titleBar.inactiveForeground": "#7C8888",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#D36F86",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#1F272F",
+    "statusBarItem.remoteBackground": "#79B7D6",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#E15E6E",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#E0AF57",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-toxic-valentine-color-theme.json
+++ b/themes/pixels-to-punk-toxic-valentine-color-theme.json
@@ -105,8 +105,8 @@
     "sideBarSectionHeader.background": "#2A1A2B",
     "sideBarSectionHeader.foreground": "#FFFFFF",
     "statusBar.background": "#211622",
-    "statusBar.debuggingBackground": "#D62F7A",
-    "statusBar.debuggingForeground": "#FFFFFF",
+    "statusBar.debuggingBackground": "#FFD34D",
+    "statusBar.debuggingForeground": "#101019",
     "statusBar.foreground": "#FFFFFF",
     "statusBar.noFolderBackground": "#211622",
     "tab.activeBackground": "#171018",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#211622",
     "titleBar.activeForeground": "#FFFFFF",
     "titleBar.inactiveBackground": "#171018",
-    "titleBar.inactiveForeground": "#A38698"
+    "titleBar.inactiveForeground": "#A38698",
+    "statusBar.noFolderForeground": "#FFFFFF",
+    "statusBarItem.activeBackground": "#FF3B8D",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#301F34",
+    "statusBarItem.remoteBackground": "#57C7FF",
+    "statusBarItem.remoteForeground": "#101019",
+    "statusBarItem.errorBackground": "#FF4E5F",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#FFD34D",
+    "statusBarItem.warningForeground": "#101019"
   },
   "tokenColors": [
     {

--- a/themes/pixels-to-punk-zine-shop-window-color-theme.json
+++ b/themes/pixels-to-punk-zine-shop-window-color-theme.json
@@ -105,7 +105,7 @@
     "sideBarSectionHeader.background": "#FFFFFF",
     "sideBarSectionHeader.foreground": "#111111",
     "statusBar.background": "#F0DAC7",
-    "statusBar.debuggingBackground": "#111111",
+    "statusBar.debuggingBackground": "#9B6500",
     "statusBar.debuggingForeground": "#FFFFFF",
     "statusBar.foreground": "#111111",
     "statusBar.noFolderBackground": "#F0DAC7",
@@ -145,7 +145,17 @@
     "titleBar.activeBackground": "#F0DAC7",
     "titleBar.activeForeground": "#111111",
     "titleBar.inactiveBackground": "#FFF4E8",
-    "titleBar.inactiveForeground": "#78696B"
+    "titleBar.inactiveForeground": "#78696B",
+    "statusBar.noFolderForeground": "#111111",
+    "statusBarItem.activeBackground": "#E91E63",
+    "statusBarItem.activeForeground": "#FFFFFF",
+    "statusBarItem.hoverBackground": "#F8E8DA",
+    "statusBarItem.remoteBackground": "#005DFF",
+    "statusBarItem.remoteForeground": "#FFFFFF",
+    "statusBarItem.errorBackground": "#C9183A",
+    "statusBarItem.errorForeground": "#FFFFFF",
+    "statusBarItem.warningBackground": "#9B6500",
+    "statusBarItem.warningForeground": "#FFFFFF"
   },
   "tokenColors": [
     {


### PR DESCRIPTION
## What changed

Adds generated status bar state colors across the full theme pack.

Covers:
- normal
- no-folder
- debugging
- remote
- warning
- error
- hover
- active item

Adds `scripts/build-status-bar-states.js` and runs it from release workflows before packaging.

## Version

Bumps the extension version to 1.0.9 for the automatic main-merge release flow.

## Documentation

Updates README.md and DEV.md with plain-language status bar docs and maintainer guidance.

## Validation

- npm run build:file-icons
- npm run build:status-bar-states
- node --check scripts/build-status-bar-states.js
- package/package-lock version check
- git diff --check
- npm run package

Closes #6