### PR TITLE
[codex] Add low glare light preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 *.vsix
 .DS_Store
+.vscode/settings.json
 .vscode-test/
 out/
 dist/

--- a/DEV.md
+++ b/DEV.md
@@ -300,6 +300,7 @@ Each preset can change:
 | Zine Shop | Pixels to Punk Zine Shop Window | Pixels to Punk Cyber Icons Light | Warm light setup for docs and notes. |
 | Maximum Neon | Pixels to Punk Riot Glow Dark | Pixels to Punk Cyber Icons | Loud neon setup. |
 | Low Glare | Pixels to Punk Soft Focus Night | Pixels to Punk Cyber Icons | Softer setup for tired eyes. |
+| Low Glare Light | Pixels to Punk Soft Focus Day | Pixels to Punk Cyber Icons Light | Softer light setup for tired eyes. |
 
 ### How People Use Them
 
@@ -320,6 +321,7 @@ They can also run a preset directly:
 - `Pixels to Punk: Apply Zine Shop Preset`
 - `Pixels to Punk: Apply Maximum Neon Preset`
 - `Pixels to Punk: Apply Low Glare Preset`
+- `Pixels to Punk: Apply Low Glare Light Preset`
 
 ### How People Undo Them
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -131,6 +131,7 @@ The moods are:
 - **Zine Shop**: warm light colors for docs and notes
 - **Maximum Neon**: the loudest neon setup
 - **Low Glare**: softer colors for tired eyes
+- **Low Glare Light**: softer light colors for tired eyes
 
 To undo a mood preset:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "pixels-to-punk-cyber",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixels-to-punk-cyber",
-      "version": "1.0.10",
+      "version": "1.0.11",
+      "license": "MIT",
       "devDependencies": {
         "@vscode/vsce": "^3.9.1"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pixels-to-punk-cyber",
   "displayName": "Pixels to Punk Cyber",
   "description": "Neon punk VS Code themes inspired by the From Pixels to Punk brand, with anime-pop color, punk energy, and coding comfort.",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "publisher": "local",
   "license": "MIT",
   "main": "./src/extension.js",
@@ -29,6 +29,7 @@
     "onCommand:pixelsToPunk.applyZineShopPreset",
     "onCommand:pixelsToPunk.applyMaximumNeonPreset",
     "onCommand:pixelsToPunk.applyLowGlarePreset",
+    "onCommand:pixelsToPunk.applyLowGlareLightPreset",
     "onCommand:pixelsToPunk.resetMoodPreset",
     "onCommand:pixelsToPunk.applyCurrentTimeOfDayTheme",
     "onCommand:pixelsToPunk.enableTimeOfDaySwitching",
@@ -72,6 +73,11 @@
       {
         "command": "pixelsToPunk.applyLowGlarePreset",
         "title": "Pixels to Punk: Apply Low Glare Preset",
+        "category": "Pixels to Punk"
+      },
+      {
+        "command": "pixelsToPunk.applyLowGlareLightPreset",
+        "title": "Pixels to Punk: Apply Low Glare Light Preset",
         "category": "Pixels to Punk"
       },
       {

--- a/src/extension.js
+++ b/src/extension.js
@@ -106,6 +106,24 @@ const presets = [
       "editor.wordWrap": "bounded",
       "terminal.integrated.tabs.enabled": false
     }
+  },
+  {
+    id: "lowGlareLight",
+    label: "Low Glare Light",
+    description: "Soft light colors for tired eyes and daylight sessions.",
+    command: "pixelsToPunk.applyLowGlareLightPreset",
+    settings: {
+      "workbench.colorTheme": "Pixels to Punk Soft Focus Day",
+      "workbench.iconTheme": "pixels-to-punk-cyber-icons-light",
+      "editor.minimap.enabled": false,
+      "editor.stickyScroll.enabled": true,
+      "editor.guides.bracketPairs": "active",
+      "editor.bracketPairColorization.enabled": true,
+      "editor.renderWhitespace": "none",
+      "editor.cursorBlinking": "smooth",
+      "editor.wordWrap": "bounded",
+      "terminal.integrated.tabs.enabled": false
+    }
   }
 ];
 


### PR DESCRIPTION
## Summary
- add a Low Glare Light workspace mood preset using Soft Focus Day and light icons
- document the new preset in DEV and QUICKSTART
- ignore local .vscode/settings.json and bump the extension version to 1.0.11

## Validation
- node -c src/extension.js
- parsed package.json and package-lock.json with Node